### PR TITLE
fix: AI 巡检通知、会话恢复与数据源定时巡检

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # ---- Stage 1: Build frontend ----
 FROM node:20-alpine AS frontend-builder
 WORKDIR /build
+ENV NPM_CONFIG_REGISTRY=https://registry.npmmirror.com
 COPY frontend/package*.json ./
 RUN npm ci --prefer-offline --no-audit
 COPY frontend/ .
@@ -8,8 +9,10 @@ RUN npm run build
 
 # ---- Stage 2: Build Go backend ----
 FROM golang:1.25-alpine AS backend-builder
+RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories
 RUN apk add --no-cache gcc musl-dev
 WORKDIR /build
+ENV GOPROXY=https://goproxy.cn,direct
 COPY go.mod go.sum ./
 COPY pi-local/ ./pi-local/
 RUN go mod download
@@ -18,10 +21,12 @@ RUN CGO_ENABLED=1 go build -ldflags="-s -w" -a -installsuffix cgo -o PromAI .
 
 # ---- Stage 3: Runtime ----
 FROM alpine:3.21
-RUN apk add --no-cache tzdata ca-certificates
+RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories \
+  && apk add --no-cache tzdata ca-certificates curl sqlite
 WORKDIR /app
 COPY --from=backend-builder /build/PromAI .
 COPY --from=frontend-builder /build/dist ./frontend/dist/
+COPY deploy/sql ./deploy/sql/
 COPY templates ./templates/
 COPY config/config.yaml ./config/config.yaml
 RUN mkdir -p /app/data /app/reports

--- a/README.md
+++ b/README.md
@@ -61,6 +61,38 @@
 | 巡检报告 | http://localhost:8091/promai/reports |
 | 触发巡检 | http://localhost:8091/promai/inspection/ |
 
+### Helm 部署
+
+```bash
+helm install promai ./deploy/helm/promai \
+  --set image.repository=promai \
+  --set image.tag=v2.0.3
+```
+
+升级：
+
+```bash
+helm upgrade promai ./deploy/helm/promai \
+  --set image.repository=promai \
+  --set image.tag=v2.0.3
+```
+
+常用配置：
+
+```yaml
+env:
+  reportUrl: "https://promai.example.com"
+bootstrapSql:
+  enabled: true
+  content: |
+    -- 自定义初始化 SQL
+```
+
+说明：
+- `env.reportUrl` 用于生成报告外链，推荐配置成外部可访问地址。
+- `deploy/helm/promai/files/metric_types_seed.sql` 是默认初始化 SQL。
+- 如果需要自定义初始化内容，直接改 `bootstrapSql.content` 或替换 `files/metric_types_seed.sql`。
+
 ## 管理后台功能
 
 | 页面 | 功能 |

--- a/admin_api.go
+++ b/admin_api.go
@@ -29,18 +29,18 @@ import (
 )
 
 type InspectTask struct {
-	ID         string `json:"id"`
-	Status     string `json:"status"` // running, completed, failed
-	Message    string `json:"message"`
-	ReportURL  string `json:"report_url,omitempty"`
-	Error      string `json:"error,omitempty"`
-	CreatedAt  time.Time `json:"created_at"`
+	ID        string    `json:"id"`
+	Status    string    `json:"status"` // running, completed, failed
+	Message   string    `json:"message"`
+	ReportURL string    `json:"report_url,omitempty"`
+	Error     string    `json:"error,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
 }
 
 var (
-	inspectTasks      = make(map[string]*InspectTask)
-	inspectTasksMu    sync.RWMutex
-	taskCounter       int64
+	inspectTasks   = make(map[string]*InspectTask)
+	inspectTasksMu sync.RWMutex
+	taskCounter    int64
 )
 
 func newTaskID() string {
@@ -224,14 +224,58 @@ func loadLatestReports() {
 	log.Printf("已加载 %d 个数据源的最新巡检快照", len(seen))
 }
 
+func populateDatasourceHealthFields(datasources []database.DataSource) {
+	if len(datasources) == 0 {
+		return
+	}
+	urls := make([]string, 0, len(datasources))
+	for _, ds := range datasources {
+		if ds.URL != "" {
+			urls = append(urls, ds.URL)
+		}
+	}
+
+	reportMap := make(map[string]database.ReportRecord, len(datasources))
+	if len(urls) > 0 {
+		var latestRecords []database.ReportRecord
+		database.DB.Where("datasource_name IN ?", urls).Order("created_at desc").Find(&latestRecords)
+		for _, r := range latestRecords {
+			if _, ok := reportMap[r.DatasourceName]; !ok {
+				reportMap[r.DatasourceName] = r
+			}
+		}
+	}
+
+	for i := range datasources {
+		ds := &datasources[i]
+		if getLatestReport(ds.URL) != nil {
+			ds.ReportStatus = "online"
+		} else {
+			ds.ReportStatus = "unknown"
+		}
+		if rec, ok := reportMap[ds.URL]; ok && rec.ID > 0 {
+			t := rec.CreatedAt
+			ds.LastReportAt = &t
+		}
+		if ds.ConnectionStatus == "" {
+			ds.ConnectionStatus = "unknown"
+		}
+		if ds.ReportStatus == "online" || ds.ConnectionStatus == "online" {
+			ds.HealthStatus = "online"
+		} else {
+			ds.HealthStatus = "unknown"
+		}
+	}
+}
+
 type AdminAPI struct {
-	collector       *metrics.Collector
-	config          *config.Config
-	authUser        string
-	authPass        string
-	jwtSecret       string
-	syncCronJobs    map[uint]cron.EntryID
-	syncCronJobsMu  sync.Mutex
+	collector      *metrics.Collector
+	config         *config.Config
+	authUser       string
+	authPass       string
+	jwtSecret      string
+	syncCronJobs   map[uint]cron.EntryID
+	syncCronJobsMu sync.Mutex
 }
 
 func NewAdminAPI(collector *metrics.Collector, cfg *config.Config) *AdminAPI {
@@ -300,6 +344,7 @@ func (a *AdminAPI) RegisterHandlers(mux *http.ServeMux) {
 	mux.HandleFunc("/api/promai/metrics/validate", logged(auth(a.handleValidatePromQL)))
 	mux.HandleFunc("/api/promai/templates", logged(auth(a.handleTemplates)))
 	mux.HandleFunc("/api/promai/templates/all", logged(auth(a.handleAllTemplates)))
+	mux.HandleFunc("/api/promai/templates/init", logged(auth(a.handleInitTemplates)))
 	mux.HandleFunc("/api/promai/templates/", logged(auth(a.handleTemplateByID)))
 	mux.HandleFunc("/api/promai/settings", logged(auth(a.handleSettings)))
 	mux.HandleFunc("/api/promai/inspect", logged(auth(a.handleInspect)))
@@ -478,13 +523,9 @@ func (a *AdminAPI) handleDataSources(w http.ResponseWriter, r *http.Request) {
 
 		var all []database.DataSource
 		query.Order("is_default desc, enabled desc, name asc").Find(&all)
+		database.NormalizeDataSourcesTemplateFields(all)
 		maskPassword(all)
-
-		for i := range all {
-			if getLatestReport(all[i].URL) != nil {
-				all[i].HealthStatus = "online"
-			}
-		}
+		populateDatasourceHealthFields(all)
 
 		if hs := r.URL.Query().Get("health_status"); hs != "" {
 			filtered := make([]database.DataSource, 0, len(all))
@@ -509,9 +550,9 @@ func (a *AdminAPI) handleDataSources(w http.ResponseWriter, r *http.Request) {
 		}
 
 		writeJSON(w, map[string]interface{}{
-			"items": all,
-			"total": total,
-			"page":  page,
+			"items":     all,
+			"total":     total,
+			"page":      page,
 			"page_size": pageSize,
 		})
 	case "POST":
@@ -524,18 +565,23 @@ func (a *AdminAPI) handleDataSources(w http.ResponseWriter, r *http.Request) {
 			writeError(w, 400, "名称和URL不能为空")
 			return
 		}
+		database.NormalizeDataSourceTemplateFields(&d)
 		d.Enabled = true
+		d.TemplateIDsRaw = database.EncodeTemplateIDs(d.TemplateIDs)
+		d.TemplateID = database.PrimaryTemplateID(d.TemplateIDs)
 		database.DB.Create(&d)
 		invalidateDSCache()
 		log.Printf("[Admin] 创建数据源: id=%d name=%s url=%s", d.ID, d.Name, d.URL)
 		w.WriteHeader(201)
 		d.Password = ""
+		database.NormalizeDataSourceTemplateFields(&d)
 		writeJSON(w, d)
 	case "PATCH":
 		var req struct {
 			IDs            []uint `json:"ids"`
 			Enabled        *bool  `json:"enabled,omitempty"`
 			TemplateID     *uint  `json:"template_id,omitempty"`
+			TemplateIDs    []uint `json:"template_ids,omitempty"`
 			NotifyChannels string `json:"notify_channels"`
 			Username       string `json:"username"`
 			Password       string `json:"password"`
@@ -559,11 +605,14 @@ func (a *AdminAPI) handleDataSources(w http.ResponseWriter, r *http.Request) {
 				log.Printf("[Admin] 数据源 %v 启用状态 -> %v", req.IDs, *req.Enabled)
 			}
 		case "set-template":
-			if req.TemplateID != nil {
-				database.DB.Model(&database.DataSource{}).Where("id IN ?", req.IDs).Update("template_id", *req.TemplateID)
-			} else {
-				database.DB.Model(&database.DataSource{}).Where("id IN ?", req.IDs).Update("template_id", nil)
+			templateIDs := req.TemplateIDs
+			if len(templateIDs) == 0 && req.TemplateID != nil && *req.TemplateID > 0 {
+				templateIDs = []uint{*req.TemplateID}
 			}
+			database.DB.Model(&database.DataSource{}).Where("id IN ?", req.IDs).Updates(map[string]interface{}{
+				"template_id":  database.PrimaryTemplateID(templateIDs),
+				"template_ids": database.EncodeTemplateIDs(templateIDs),
+			})
 		case "set-notify":
 			database.DB.Model(&database.DataSource{}).Where("id IN ?", req.IDs).Update("notify_channels", req.NotifyChannels)
 		case "apply-template":
@@ -572,7 +621,10 @@ func (a *AdminAPI) handleDataSources(w http.ResponseWriter, r *http.Request) {
 				writeError(w, 500, "全局模板不存在")
 				return
 			}
-			database.DB.Model(&database.DataSource{}).Where("id IN ?", req.IDs).Update("template_id", globalTmpl.ID)
+			database.DB.Model(&database.DataSource{}).Where("id IN ?", req.IDs).Updates(map[string]interface{}{
+				"template_id":  globalTmpl.ID,
+				"template_ids": database.EncodeTemplateIDs([]uint{globalTmpl.ID}),
+			})
 		case "inspect":
 			var dss []database.DataSource
 			database.DB.Find(&dss, "id IN ?", req.IDs)
@@ -625,11 +677,7 @@ func (a *AdminAPI) handleAllDataSources(w http.ResponseWriter, r *http.Request) 
 		dsCacheMu.RUnlock()
 		result := make([]database.DataSource, len(cached))
 		copy(result, cached)
-		for i := range result {
-			if getLatestReport(result[i].URL) != nil {
-				result[i].HealthStatus = "online"
-			}
-		}
+		populateDatasourceHealthFields(result)
 		w.Header().Set("X-Cache", "HIT")
 		writeJSON(w, result)
 		return
@@ -640,12 +688,9 @@ func (a *AdminAPI) handleAllDataSources(w http.ResponseWriter, r *http.Request) 
 	database.DB.Model(&database.DataSource{}).
 		Order("is_default desc, enabled desc, name asc").
 		Find(&ds)
+	database.NormalizeDataSourcesTemplateFields(ds)
 	maskPassword(ds)
-	for i := range ds {
-		if getLatestReport(ds[i].URL) != nil {
-			ds[i].HealthStatus = "online"
-		}
-	}
+	populateDatasourceHealthFields(ds)
 
 	dsCacheMu.Lock()
 	dsCache = ds
@@ -677,7 +722,11 @@ func (a *AdminAPI) handleDataSourceByID(w http.ResponseWriter, r *http.Request) 
 			writeError(w, 404, "数据源不存在")
 			return
 		}
+		database.NormalizeDataSourceTemplateFields(&d)
 		d.Password = ""
+		items := []database.DataSource{d}
+		populateDatasourceHealthFields(items)
+		d = items[0]
 		writeJSON(w, d)
 	case "PUT":
 		var d database.DataSource
@@ -694,6 +743,11 @@ func (a *AdminAPI) handleDataSourceByID(w http.ResponseWriter, r *http.Request) 
 		delete(upd, "created_at")
 		delete(upd, "updated_at")
 		delete(upd, "health_status")
+		delete(upd, "report_status")
+		delete(upd, "last_report_at")
+		delete(upd, "connection_status")
+		delete(upd, "connection_checked_at")
+		delete(upd, "template_ids_raw")
 		if pw, ok := upd["password"]; ok {
 			if pw == nil {
 				delete(upd, "password")
@@ -701,10 +755,22 @@ func (a *AdminAPI) handleDataSourceByID(w http.ResponseWriter, r *http.Request) 
 				delete(upd, "password")
 			}
 		}
+		templateIDs := extractTemplateIDsFromPayload(upd["template_ids"])
+		_, hasTemplateID := upd["template_id"]
+		if len(templateIDs) == 0 {
+			if templateID := extractTemplateIDFromPayload(upd["template_id"]); templateID != nil {
+				templateIDs = []uint{*templateID}
+			}
+		}
+		if _, ok := upd["template_ids"]; ok || hasTemplateID {
+			upd["template_ids"] = database.EncodeTemplateIDs(templateIDs)
+			upd["template_id"] = database.PrimaryTemplateID(templateIDs)
+		}
 		database.DB.Model(&d).Updates(upd)
 		database.DB.First(&d, id)
 		invalidateDSCache()
 		log.Printf("[Admin] 更新数据源: id=%d name=%s", id, d.Name)
+		database.NormalizeDataSourceTemplateFields(&d)
 		d.Password = ""
 		writeJSON(w, d)
 	case "DELETE":
@@ -790,8 +856,11 @@ func (a *AdminAPI) handleApplyTemplate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// 设置数据源的 template_id 为全局模板
-	database.DB.Model(&ds).Update("template_id", globalTmpl.ID)
+	database.DB.Model(&ds).Updates(map[string]interface{}{
+		"template_id":  globalTmpl.ID,
+		"template_ids": database.EncodeTemplateIDs([]uint{globalTmpl.ID}),
+	})
+	invalidateDSCache()
 
 	var count int64
 	database.DB.Model(&database.InspectionTemplateMetric{}).Where("template_id = ?", globalTmpl.ID).Count(&count)
@@ -1072,42 +1141,39 @@ func (a *AdminAPI) handleMetricTypes(w http.ResponseWriter, r *http.Request) {
 	case "GET":
 		filterDS := r.URL.Query().Get("datasource_id")
 
-		// 如果按数据源筛选，检查数据源是否绑定了巡检模板
-		var templateConfigIDs []uint
-		var tmplID *uint
+		var mTypes []database.MetricType
+		database.DB.Order("sort_order asc, id asc").Find(&mTypes)
+
+		configMap := make(map[uint][]database.MetricConfig)
 		if filterDS != "" {
 			var ds database.DataSource
-			if database.DB.First(&ds, filterDS).Error == nil && ds.TemplateID != nil {
-				tmplID = ds.TemplateID
-				var links []database.InspectionTemplateMetric
-				database.DB.Where("template_id = ?", *ds.TemplateID).Find(&links)
-				for _, l := range links {
-					templateConfigIDs = append(templateConfigIDs, l.MetricConfigID)
+			if database.DB.First(&ds, filterDS).Error == nil {
+				database.NormalizeDataSourceTemplateFields(&ds)
+				configs, err := loadEffectiveMetricConfigs(&ds)
+				if err != nil {
+					writeError(w, 500, fmt.Sprintf("加载数据源指标失败: %v", err))
+					return
 				}
+				for _, cfg := range configs {
+					configMap[cfg.MetricTypeID] = append(configMap[cfg.MetricTypeID], cfg)
+				}
+			}
+		} else {
+			for i := range mTypes {
+				var configs []database.MetricConfig
+				database.DB.Where("metric_type_id = ?", mTypes[i].ID).
+					Order("sort_order asc, id asc").
+					Find(&configs)
+				configMap[mTypes[i].ID] = configs
 			}
 		}
 
-		var mTypes []database.MetricType
-		database.DB.Order("sort_order asc, id asc").Find(&mTypes)
 		for i := range mTypes {
-			configs := []database.MetricConfig{}
-			q := database.DB.Where("metric_type_id = ?", mTypes[i].ID)
-			if len(templateConfigIDs) > 0 {
-				q = q.Where("id IN ?", templateConfigIDs)
-			} else if filterDS != "" {
-				q = q.Where("(datasource_id IS NULL OR datasource_id = ?)", filterDS)
+			if configs, ok := configMap[mTypes[i].ID]; ok {
+				mTypes[i].Configs = configs
+			} else {
+				mTypes[i].Configs = []database.MetricConfig{}
 			}
-			q.Order("sort_order asc").Find(&configs)
-			// 合并模板 override（如果有）
-			if tmplID != nil {
-				for j := range configs {
-					var override database.TemplateMetricOverride
-					if database.DB.Where("template_id = ? AND metric_config_id = ?", *tmplID, configs[j].ID).First(&override).Error == nil {
-						override.Apply(&configs[j])
-					}
-				}
-			}
-			mTypes[i].Configs = configs
 		}
 		writeJSON(w, mTypes)
 	case "POST":
@@ -1284,11 +1350,11 @@ func (a *AdminAPI) handleValidatePromQL(w http.ResponseWriter, r *http.Request) 
 		}
 
 		writeJSON(w, map[string]interface{}{
-			"valid":     true,
-			"type":      "vector",
-			"labels":    labels,
-			"count":     len(samples),
-			"samples":   samples[:min(len(samples), 10)],
+			"valid":   true,
+			"type":    "vector",
+			"labels":  labels,
+			"count":   len(samples),
+			"samples": samples[:min(len(samples), 10)],
 		})
 	case model.Matrix:
 		writeJSON(w, map[string]interface{}{
@@ -1353,11 +1419,21 @@ func (a *AdminAPI) handleSettings(w http.ResponseWriter, r *http.Request) {
 			tokens, hasT := m["ai_max_tokens"]
 			if hasP || hasM || hasB || hasK || hasL || hasT {
 				mc := config.AIModelConfig{Name: "default"}
-				if hasP { mc.Provider = provider }
-				if hasM { mc.Model = model }
-				if hasB { mc.BaseURL = baseURL }
-				if hasL { mc.ThinkingLevel = level }
-				if hasT { fmt.Sscanf(tokens, "%d", &mc.MaxTokens) }
+				if hasP {
+					mc.Provider = provider
+				}
+				if hasM {
+					mc.Model = model
+				}
+				if hasB {
+					mc.BaseURL = baseURL
+				}
+				if hasL {
+					mc.ThinkingLevel = level
+				}
+				if hasT {
+					fmt.Sscanf(tokens, "%d", &mc.MaxTokens)
+				}
 				if b, _ := json.Marshal([]config.AIModelConfig{mc}); b != nil {
 					m["ai_models"] = string(b)
 				}
@@ -1371,80 +1447,80 @@ func (a *AdminAPI) handleSettings(w http.ResponseWriter, r *http.Request) {
 			writeError(w, 400, "请求体格式错误")
 			return
 		}
-	for k, v := range updates {
-		if k == "ai_models" {
-			// 解析、加密 API Key、写回 DB
-			var models []config.AIModelConfig
-			if err := json.Unmarshal([]byte(v), &models); err != nil {
-				writeError(w, 400, "ai_models 格式错误")
-				return
-			}
-			// 加载旧的 models 以保留未修改的 Key
-			var oldRaw string
-			var oldSetting database.AppSetting
-			if database.DB.Where("key = ?", "ai_models").First(&oldSetting).Error == nil {
-				oldRaw = oldSetting.Value
-			}
-			var oldModels []config.AIModelConfig
-			json.Unmarshal([]byte(oldRaw), &oldModels)
-			oldMap := make(map[string]string)
-			for _, om := range oldModels {
-				oldMap[om.Name] = om.APIKey
-			}
-			for i := range models {
-				if models[i].APIKey == "" || models[i].APIKey == "********" {
-					// 保持已有值（加密或明文）
-					if oldKey, ok := oldMap[models[i].Name]; ok {
-						models[i].APIKey = oldKey
-					} else {
-						models[i].APIKey = ""
-					}
-				} else {
-					encrypted, err := piagent.EncryptAPIKey(models[i].APIKey, a.jwtSecret)
-					if err != nil {
-						writeError(w, 500, "加密 API Key 失败")
-						return
-					}
-					models[i].APIKey = "enc:" + encrypted
+		for k, v := range updates {
+			if k == "ai_models" {
+				// 解析、加密 API Key、写回 DB
+				var models []config.AIModelConfig
+				if err := json.Unmarshal([]byte(v), &models); err != nil {
+					writeError(w, 400, "ai_models 格式错误")
+					return
 				}
+				// 加载旧的 models 以保留未修改的 Key
+				var oldRaw string
+				var oldSetting database.AppSetting
+				if database.DB.Where("key = ?", "ai_models").First(&oldSetting).Error == nil {
+					oldRaw = oldSetting.Value
+				}
+				var oldModels []config.AIModelConfig
+				json.Unmarshal([]byte(oldRaw), &oldModels)
+				oldMap := make(map[string]string)
+				for _, om := range oldModels {
+					oldMap[om.Name] = om.APIKey
+				}
+				for i := range models {
+					if models[i].APIKey == "" || models[i].APIKey == "********" {
+						// 保持已有值（加密或明文）
+						if oldKey, ok := oldMap[models[i].Name]; ok {
+							models[i].APIKey = oldKey
+						} else {
+							models[i].APIKey = ""
+						}
+					} else {
+						encrypted, err := piagent.EncryptAPIKey(models[i].APIKey, a.jwtSecret)
+						if err != nil {
+							writeError(w, 500, "加密 API Key 失败")
+							return
+						}
+						models[i].APIKey = "enc:" + encrypted
+					}
+				}
+				encBytes, _ := json.Marshal(models)
+				v = string(encBytes)
+			} else if k == "ai_api_key" {
+				if v == "" || v == "********" {
+					continue
+				}
+				encrypted, err := piagent.EncryptAPIKey(v, a.jwtSecret)
+				if err != nil {
+					writeError(w, 500, "加密 API Key 失败")
+					return
+				}
+				v = "enc:" + encrypted
 			}
-			encBytes, _ := json.Marshal(models)
-			v = string(encBytes)
-		} else if k == "ai_api_key" {
-			if v == "" || v == "********" {
-				continue
+			var s database.AppSetting
+			if database.DB.Where("key = ?", k).First(&s).Error != nil {
+				database.DB.Create(&database.AppSetting{Key: k, Value: v})
+			} else {
+				database.DB.Model(&s).Update("value", v)
 			}
-			encrypted, err := piagent.EncryptAPIKey(v, a.jwtSecret)
-			if err != nil {
-				writeError(w, 500, "加密 API Key 失败")
-				return
+			// 同步到内存中的配置
+			if k == "cron_schedule" && a.config != nil {
+				a.config.CronSchedule = v
 			}
-			v = "enc:" + encrypted
+			a.syncAIConfigSetting(k, v)
 		}
-		var s database.AppSetting
-		if database.DB.Where("key = ?", k).First(&s).Error != nil {
-			database.DB.Create(&database.AppSetting{Key: k, Value: v})
-		} else {
-			database.DB.Model(&s).Update("value", v)
+		// 如果更新了定时调度，重启调度器
+		if _, ok := updates["cron_schedule"]; ok {
+			log.Printf("[Admin] 更新定时调度: %s", updates["cron_schedule"])
+			startGlobalScheduler(a.config, a.collector)
 		}
-		// 同步到内存中的配置
-		if k == "cron_schedule" && a.config != nil {
-			a.config.CronSchedule = v
+		if _, ok := updates["ai_enabled"]; ok {
+			log.Printf("[Admin] AI 助手启用状态: %s", updates["ai_enabled"])
 		}
-		a.syncAIConfigSetting(k, v)
-	}
-	// 如果更新了定时调度，重启调度器
-	if _, ok := updates["cron_schedule"]; ok {
-		log.Printf("[Admin] 更新定时调度: %s", updates["cron_schedule"])
-		startGlobalScheduler(a.config, a.collector)
-	}
-	if _, ok := updates["ai_enabled"]; ok {
-		log.Printf("[Admin] AI 助手启用状态: %s", updates["ai_enabled"])
-	}
-	if _, ok := updates["ai_models"]; ok {
-		log.Printf("[Admin] AI 模型配置已更新")
-	}
-	writeJSON(w, updates)
+		if _, ok := updates["ai_models"]; ok {
+			log.Printf("[Admin] AI 模型配置已更新")
+		}
+		writeJSON(w, updates)
 	default:
 		writeError(w, 405, "不支持的请求方法")
 	}
@@ -1555,16 +1631,10 @@ func (a *AdminAPI) handleInspect(w http.ResponseWriter, r *http.Request) {
 	promUser := a.config.PrometheusUsername
 	promPass := a.config.PrometheusPassword
 
-	if req.DatasourceURL != "" {
-		promURL = req.DatasourceURL
-	} else if req.DatasourceID > 0 {
-		var ds database.DataSource
-		if database.DB.First(&ds, req.DatasourceID).Error == nil {
-			promURL = ds.URL
-			promUser = ds.Username
-			promPass = ds.Password
-		}
-	}
+	ds, promURLResolved, promUserResolved, promPassResolved := resolveDatasourceConnection(a.config, req.DatasourceID, req.DatasourceURL)
+	promURL = promURLResolved
+	promUser = promUserResolved
+	promPass = promPassResolved
 
 	taskID := newTaskID()
 	log.Printf("[Admin] 触发巡检: datasource_id=%d url=%s task_id=%s", req.DatasourceID, promURL, taskID)
@@ -1579,16 +1649,18 @@ func (a *AdminAPI) handleInspect(w http.ResponseWriter, r *http.Request) {
 	inspectTasksMu.Unlock()
 
 	dsName := promURL
-	if req.DatasourceID > 0 {
-		var ds database.DataSource
-		if database.DB.First(&ds, req.DatasourceID).Error == nil {
-			dsName = ds.Name
-		}
+	if ds != nil {
+		dsName = ds.Name
 	}
 	database.DB.Create(&database.InspectRecord{
-		TaskID:         taskID,
-		Status:         "running",
-		DatasourceID:   func() *uint { if req.DatasourceID > 0 { return &req.DatasourceID }; return nil }(),
+		TaskID: taskID,
+		Status: "running",
+		DatasourceID: func() *uint {
+			if req.DatasourceID > 0 {
+				return &req.DatasourceID
+			}
+			return nil
+		}(),
 		DatasourceName: dsName,
 		Message:        "巡检任务已创建，正在执行...",
 		StartedAt:      time.Now(),
@@ -1612,6 +1684,7 @@ func (a *AdminAPI) runInspect(task *InspectTask, promURL, promUser, promPass str
 }) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
+	runtimeDS, _, _, _ := resolveDatasourceConnection(a.config, req.DatasourceID, req.DatasourceURL)
 
 	done := make(chan struct{})
 	var runErr error
@@ -1620,6 +1693,7 @@ func (a *AdminAPI) runInspect(task *InspectTask, promURL, promUser, promPass str
 
 	go func() {
 		defer close(done)
+		checkTime := time.Now()
 
 		client, err := prometheus.NewClient(promURL, promUser, promPass)
 		if err != nil {
@@ -1631,49 +1705,34 @@ func (a *AdminAPI) runInspect(task *InspectTask, promURL, promUser, promPass str
 		hcCtx, hcCancel := context.WithTimeout(context.Background(), 10*time.Second)
 		if err := client.HealthCheck(hcCtx); err != nil {
 			hcCancel()
+			if runtimeDS != nil {
+				database.DB.Model(&database.DataSource{}).Where("id = ?", runtimeDS.ID).Updates(map[string]interface{}{
+					"connection_status":     "unknown",
+					"connection_checked_at": &checkTime,
+				})
+				invalidateDSCache()
+			}
 			runErr = fmt.Errorf("数据源 %s 不可用: %v", promURL, err)
 			return
 		}
 		hcCancel()
+		if runtimeDS != nil {
+			database.DB.Model(&database.DataSource{}).Where("id = ?", runtimeDS.ID).Updates(map[string]interface{}{
+				"connection_status":     "online",
+				"connection_checked_at": &checkTime,
+			})
+			invalidateDSCache()
+		}
 
 		activeConfig := a.config
 		if len(req.MetricConfigIDs) > 0 {
 			var selectedConfigs []database.MetricConfig
 			database.DB.Where("id IN ?", req.MetricConfigIDs).Find(&selectedConfigs)
 			if len(selectedConfigs) > 0 {
-				activeConfig = buildFilteredConfig(activeConfig, selectedConfigs)
+				activeConfig = buildRuntimeMetricConfig(activeConfig, runtimeDS, selectedConfigs)
 			}
-		} else if req.DatasourceID > 0 {
-			var ds database.DataSource
-			if database.DB.First(&ds, req.DatasourceID).Error == nil {
-				if ds.TemplateID != nil {
-					var links []database.InspectionTemplateMetric
-					database.DB.Where("template_id = ?", *ds.TemplateID).Find(&links)
-					if len(links) > 0 {
-						cfgIDs := make([]uint, len(links))
-						for i, l := range links {
-							cfgIDs[i] = l.MetricConfigID
-						}
-						var tmplConfigs []database.MetricConfig
-						database.DB.Where("id IN ?", cfgIDs).Find(&tmplConfigs)
-						for i := range tmplConfigs {
-							var override database.TemplateMetricOverride
-							if database.DB.Where("template_id = ? AND metric_config_id = ?", *ds.TemplateID, tmplConfigs[i].ID).First(&override).Error == nil {
-								override.Apply(&tmplConfigs[i])
-							}
-						}
-						if len(tmplConfigs) > 0 {
-							activeConfig = buildFilteredConfig(activeConfig, tmplConfigs)
-						}
-					}
-				} else {
-					var dsConfigs []database.MetricConfig
-					database.DB.Where("(datasource_id IS NULL OR datasource_id = ?) AND metric_type_id IS NOT NULL", req.DatasourceID).Find(&dsConfigs)
-					if len(dsConfigs) > 0 {
-						activeConfig = buildFilteredConfig(activeConfig, dsConfigs)
-					}
-				}
-			}
+		} else if runtimeDS != nil {
+			activeConfig = buildRuntimeMetricConfig(activeConfig, runtimeDS, nil)
 		}
 
 		dataCollector := metrics.NewCollectorWithURL(client.API, activeConfig, promURL)
@@ -1697,7 +1756,11 @@ func (a *AdminAPI) runInspect(task *InspectTask, promURL, promUser, promPass str
 			if a.config.Notifications.WeChatWork.ProxyURL != "" {
 				proxyURL = a.config.Notifications.WeChatWork.ProxyURL
 			}
-			notify.SendWeChatWorkWithWebhook(context.Background(), req.WechatBotKey, proxyURL, reportPath, a.config.ProjectName, promURL, alertSummary)
+			projectName := data.Project
+			if projectName == "" {
+				projectName = a.config.ProjectName
+			}
+			notify.SendWeChatWorkWithWebhook(context.Background(), req.WechatBotKey, proxyURL, reportPath, projectName, promURL, alertSummary)
 		}
 
 		if req.DatasourceID > 0 {
@@ -1855,39 +1918,62 @@ func (a *AdminAPI) handleInspectRecords(w http.ResponseWriter, r *http.Request) 
 
 // buildFilteredConfig builds a config.Config from a filtered set of MetricConfig rows
 func buildFilteredConfig(base *config.Config, selectedConfigs []database.MetricConfig) *config.Config {
-	typeMap := make(map[uint][]database.MetricConfig)
-	for _, c := range selectedConfigs {
-		typeMap[c.MetricTypeID] = append(typeMap[c.MetricTypeID], c)
-	}
-	var filteredTypes []config.MetricType
-	for mtID, configs := range typeMap {
-		var mt database.MetricType
-		if database.DB.First(&mt, mtID).Error != nil {
-			continue
-		}
-		mtCfg := config.MetricType{Type: mt.TypeName}
-		for _, c := range configs {
-			var labels map[string]string
-			if c.LabelsJSON != "" {
-				json.Unmarshal([]byte(c.LabelsJSON), &labels)
+	return buildRuntimeMetricConfig(base, nil, selectedConfigs)
+}
+
+func extractTemplateIDsFromPayload(raw any) []uint {
+	switch v := raw.(type) {
+	case nil:
+		return nil
+	case []uint:
+		return v
+	case []any:
+		ids := make([]uint, 0, len(v))
+		for _, item := range v {
+			switch n := item.(type) {
+			case float64:
+				if n > 0 {
+					ids = append(ids, uint(n))
+				}
+			case int:
+				if n > 0 {
+					ids = append(ids, uint(n))
+				}
 			}
-			mtCfg.Metrics = append(mtCfg.Metrics, config.MetricConfig{
-				Name:            c.Name,
-				Description:     c.Description,
-				Query:           c.Query,
-				Threshold:       c.Threshold,
-				Unit:            c.Unit,
-				Labels:          labels,
-				ThresholdType:   c.ThresholdType,
-				ThresholdStatus: c.ThresholdStatus,
-			})
 		}
-		filteredTypes = append(filteredTypes, mtCfg)
+		return ids
+	case string:
+		return database.ParseTemplateIDs(v)
+	default:
+		return nil
 	}
-	cfg := &config.Config{}
-	*cfg = *base
-	cfg.MetricTypes = filteredTypes
-	return cfg
+}
+
+func extractTemplateIDFromPayload(raw any) *uint {
+	switch v := raw.(type) {
+	case nil:
+		return nil
+	case float64:
+		if v <= 0 {
+			return nil
+		}
+		id := uint(v)
+		return &id
+	case int:
+		if v <= 0 {
+			return nil
+		}
+		id := uint(v)
+		return &id
+	case uint:
+		if v == 0 {
+			return nil
+		}
+		id := v
+		return &id
+	default:
+		return nil
+	}
 }
 
 func (a *AdminAPI) handleBindMetrics(w http.ResponseWriter, r *http.Request) {
@@ -1995,6 +2081,21 @@ func (a *AdminAPI) handleAllTemplates(w http.ResponseWriter, r *http.Request) {
 		results = append(results, result{InspectionTemplate: t, MetricCount: int(count)})
 	}
 	writeJSON(w, results)
+}
+
+func (a *AdminAPI) handleInitTemplates(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		writeError(w, 405, "不支持的请求方法")
+		return
+	}
+	if err := database.InitializeTemplatesFromMetricTypes(); err != nil {
+		writeError(w, 500, fmt.Sprintf("初始化模板失败: %v", err))
+		return
+	}
+	writeJSON(w, map[string]interface{}{
+		"success": true,
+		"message": "模板初始化完成",
+	})
 }
 
 func (a *AdminAPI) handleTemplateByID(w http.ResponseWriter, r *http.Request) {
@@ -2221,20 +2322,7 @@ func (a *AdminAPI) handleTemplateInspect(w http.ResponseWriter, r *http.Request)
 		}
 	}
 
-	// Build prometheus URL
-	promURL := a.config.PrometheusURL
-	promUser := a.config.PrometheusUsername
-	promPass := a.config.PrometheusPassword
-	if req.DatasourceURL != "" {
-		promURL = req.DatasourceURL
-	} else if req.DatasourceID > 0 {
-		var ds database.DataSource
-		if database.DB.First(&ds, req.DatasourceID).Error == nil {
-			promURL = ds.URL
-			promUser = ds.Username
-			promPass = ds.Password
-		}
-	}
+	ds, promURL, promUser, promPass := resolveDatasourceConnection(a.config, req.DatasourceID, req.DatasourceURL)
 
 	client, err := prometheus.NewClient(promURL, promUser, promPass)
 	if err != nil {
@@ -2251,7 +2339,7 @@ func (a *AdminAPI) handleTemplateInspect(w http.ResponseWriter, r *http.Request)
 	}
 	hcCancel()
 
-	activeConfig := buildFilteredConfig(a.config, selectedConfigs)
+	activeConfig := buildRuntimeMetricConfig(a.config, ds, selectedConfigs)
 	dataCollector := metrics.NewCollectorWithURL(client.API, activeConfig, promURL)
 	data, err := dataCollector.CollectMetrics()
 	if err != nil {
@@ -2302,11 +2390,11 @@ func (a *AdminAPI) handleTestNotification(w http.ResponseWriter, r *http.Request
 	}
 
 	testSummary := notify.AlertSummary{
-		TotalMetrics:  3,
-		TotalAlerts:   1,
+		TotalMetrics:   3,
+		TotalAlerts:    1,
 		CriticalAlerts: 0,
-		WarningAlerts: 1,
-		NormalMetrics: 2,
+		WarningAlerts:  1,
+		NormalMetrics:  2,
 	}
 
 	switch nc.ChannelType {
@@ -2366,12 +2454,24 @@ func (a *AdminAPI) handleTestDatasource(w http.ResponseWriter, r *http.Request) 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	if err := client.HealthCheck(ctx); err != nil {
+		now := time.Now()
+		database.DB.Model(&ds).Updates(map[string]interface{}{
+			"connection_status":     "unknown",
+			"connection_checked_at": &now,
+		})
+		invalidateDSCache()
 		writeJSON(w, map[string]interface{}{
 			"success": false,
 			"message": fmt.Sprintf("连接失败: %v", err),
 		})
 		return
 	}
+	now := time.Now()
+	database.DB.Model(&ds).Updates(map[string]interface{}{
+		"connection_status":     "online",
+		"connection_checked_at": &now,
+	})
+	invalidateDSCache()
 	writeJSON(w, map[string]interface{}{
 		"success": true,
 		"message": "连接成功",
@@ -2389,36 +2489,21 @@ func (a *AdminAPI) handleDashboardStats(w http.ResponseWriter, r *http.Request) 
 	database.DB.Order("created_at desc").Limit(5).Find(&recentReports)
 
 	writeJSON(w, map[string]interface{}{
-		"total_datasources":  dsCount,
-		"total_cronjobs":     cronCount,
-		"total_reports":      reportCount,
+		"total_datasources":   dsCount,
+		"total_cronjobs":      cronCount,
+		"total_reports":       reportCount,
 		"total_notifications": notifCount,
-		"recent_reports":     recentReports,
+		"recent_reports":      recentReports,
 	})
 }
 
 func (a *AdminAPI) getDatasourceMetricConfigs(ds database.DataSource) []database.MetricConfig {
-	if ds.TemplateID != nil {
-		var links []database.InspectionTemplateMetric
-		database.DB.Where("template_id = ?", *ds.TemplateID).Find(&links)
-		if len(links) > 0 {
-			cfgIDs := make([]uint, len(links))
-			for i, l := range links {
-				cfgIDs[i] = l.MetricConfigID
-			}
-			var configs []database.MetricConfig
-			database.DB.Where("id IN ?", cfgIDs).Find(&configs)
-			for i := range configs {
-				var override database.TemplateMetricOverride
-				if database.DB.Where("template_id = ? AND metric_config_id = ?", *ds.TemplateID, configs[i].ID).First(&override).Error == nil {
-					override.Apply(&configs[i])
-				}
-			}
-			return configs
-		}
+	database.NormalizeDataSourceTemplateFields(&ds)
+	configs, err := loadEffectiveMetricConfigs(&ds)
+	if err != nil {
+		log.Printf("[Admin] 加载数据源 %s 指标失败: %v", ds.Name, err)
+		return nil
 	}
-	var configs []database.MetricConfig
-	database.DB.Where("(datasource_id IS NULL OR datasource_id = ?) AND metric_type_id IS NOT NULL", ds.ID).Find(&configs)
 	return configs
 }
 
@@ -2491,17 +2576,22 @@ func (a *AdminAPI) handleDashboardHealth(w http.ResponseWriter, r *http.Request)
 
 		snapshot := getLatestReport(ds.URL)
 		if snapshot == nil {
-		lastReportURL := ""
-		if lastReport.ID > 0 && lastReport.FilePath != "" {
-			lastReportURL = "/api/promai/reports/" + filepath.Base(lastReport.FilePath)
-		}
-		results = append(results, DatasourceHealth{
-			Datasource:    ds,
-			Metrics:       []HealthMetric{},
-			LastReportAt:  func() *time.Time { if lastReport.ID > 0 { return &lastReport.CreatedAt }; return nil }(),
-			LastReportURL: lastReportURL,
-			TypeSummaries: []TypeSummaryItem{},
-		})
+			lastReportURL := ""
+			if lastReport.ID > 0 && lastReport.FilePath != "" {
+				lastReportURL = "/api/promai/reports/" + filepath.Base(lastReport.FilePath)
+			}
+			results = append(results, DatasourceHealth{
+				Datasource: ds,
+				Metrics:    []HealthMetric{},
+				LastReportAt: func() *time.Time {
+					if lastReport.ID > 0 {
+						return &lastReport.CreatedAt
+					}
+					return nil
+				}(),
+				LastReportURL: lastReportURL,
+				TypeSummaries: []TypeSummaryItem{},
+			})
 			continue
 		}
 
@@ -2563,7 +2653,12 @@ func (a *AdminAPI) handleDashboardHealth(w http.ResponseWriter, r *http.Request)
 			WarningCount:  snapshot.WarningCount,
 			NormalCount:   snapshot.TotalMetrics - alerts,
 			HealthScore:   healthScore,
-			LastReportAt:  func() *time.Time { if lastReport.ID > 0 { return &lastReport.CreatedAt }; return nil }(),
+			LastReportAt: func() *time.Time {
+				if lastReport.ID > 0 {
+					return &lastReport.CreatedAt
+				}
+				return nil
+			}(),
 			LastReportURL: lastReportURL,
 			Metrics:       metrics,
 			TypeSummaries: typeSummaries,

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -35,7 +35,7 @@ spec:
             type: ''
       containers:
         - name: promai
-          image: 'kubehan/promai:latest'
+          image: promai:v2.0.0 
           ports:
             - name: tcp-8091
               containerPort: 8091
@@ -43,9 +43,11 @@ spec:
           env:
             - name: EXTERNAL_PORT
               value: '80'
+            - name: REPORT_URL
+              value: 'https://your-promai.example.com'
             - name: PROMETHEUS_URL
               value: >-
-                http://prometheus-k8s.kubesphere-monitoring-system.svc.cluster.local:9090
+                http://prometheus.monitor.svc.cluster.local:30900
           resources:
             limits:
               cpu: 20m

--- a/deploy/helm/promai/Chart.yaml
+++ b/deploy/helm/promai/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: promai
+description: Helm chart for PromAI
+type: application
+version: 0.1.0
+appVersion: "v2.0.2"

--- a/deploy/helm/promai/templates/deployment.yaml
+++ b/deploy/helm/promai/templates/deployment.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "promai.fullname" . }}
+  labels:
+    {{- include "promai.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "promai.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "promai.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: promai
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.targetPort }}
+          env:
+            - name: PROMAI_DB_PATH
+              value: {{ .Values.env.dbPath | quote }}
+            - name: PROMAI_IMPORT_SQL_ON_START
+              value: {{ ternary "true" "false" .Values.bootstrapSql.enabled | quote }}
+            - name: PROMAI_IMPORT_SQL_FILE
+              value: {{ .Values.bootstrapSql.filePath | quote }}
+            - name: PROMETHEUS_URL
+              value: {{ .Values.env.prometheusUrl | quote }}
+            - name: TZ
+              value: {{ .Values.env.timezone | quote }}
+            - name: EXTERNAL_PORT
+              value: {{ .Values.env.externalPort | quote }}
+            - name: REPORT_URL
+              value: {{ .Values.env.reportUrl | quote }}
+          volumeMounts:
+            - name: config
+              mountPath: /app/config
+            {{- if .Values.bootstrapSql.enabled }}
+            - name: bootstrap-sql
+              mountPath: /app/bootstrap
+              readOnly: true
+            {{- end }}
+            - name: data
+              mountPath: /app/data
+            - name: data
+              subPath: reports
+              mountPath: /app/reports
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "promai.configMapName" . }}
+        {{- if .Values.bootstrapSql.enabled }}
+        - name: bootstrap-sql
+          configMap:
+            name: {{ include "promai.bootstrapSqlMountedConfigMapName" . }}
+        {{- end }}
+        - name: data
+          {{- if or .Values.persistence.enabled .Values.persistence.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ include "promai.pvcName" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}

--- a/deploy/helm/promai/values.yaml
+++ b/deploy/helm/promai/values.yaml
@@ -1,0 +1,102 @@
+replicaCount: 1
+
+image:
+  repository: promai
+  tag: v2.0.2
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 8091
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+  hosts:
+    - host: ""
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+resources:
+  requests:
+    memory: 64Mi
+    cpu: 50m
+  limits:
+    memory: 256Mi
+    cpu: 200m
+
+persistence:
+  enabled: true
+  existingClaim: ""
+  accessModes:
+    - ReadWriteOnce
+  size: 5Gi
+  storageClassName: local-path
+
+env:
+  timezone: Asia/Shanghai
+  prometheusUrl: http://prometheus.monitor.svc.cluster.local:9090
+  # 仅在根据当前请求动态拼接外部访问地址时，补充外部端口。
+  # 如果外部访问本身就是标准端口 80/443，通常不需要改它。
+  externalPort: "80"
+  # 报告对外访问的完整基础地址，优先级高于 externalPort。
+  # 例如: https://promai.example.com
+  reportUrl: ""
+  dbPath: /app/data/promai.db
+
+bootstrapSql:
+  enabled: true
+  existingConfigMap: ""
+  filePath: /app/bootstrap/metric_types_seed.sql
+  content: ""
+
+config:
+  content: |
+    # 如果这里配置了 metric_types，PromAI 启动时会优先使用 config.yaml，不会执行 SQL 初始化。
+    # 如果这里不配置 metric_types，且 bootstrapSql.enabled=true，则会执行 SQL 初始化。
+    prometheus_url: "http://prometheus-k8s.monitoring.svc.cluster.local:9090"
+    project_name: "PromAI"
+    cron_schedule: "00 08,17 * * *"
+    auth:
+      username: "admin"
+      password: "promai2024"
+      jwt_secret: "promai-jwt-secret-change-in-production"
+    report_cleanup:
+      enabled: true
+      max_age: 7
+      cron_schedule: "0 0 * * *"
+    notifications:
+      dingtalk:
+        enabled: false
+        webhook: ""
+        secret: ""
+        report_url: ""
+      wechat_work:
+        enabled: false
+        webhook: ""
+        proxy_url: ""
+        report_url: ""
+      email:
+        enabled: false
+
+livenessProbe:
+  httpGet:
+    path: /api/promai
+    port: 8091
+  initialDelaySeconds: 30
+  periodSeconds: 10
+
+readinessProbe:
+  httpGet:
+    path: /api/promai
+    port: 8091
+  initialDelaySeconds: 5
+  periodSeconds: 5

--- a/deploy/k8s-deploy-pvc.yaml
+++ b/deploy/k8s-deploy-pvc.yaml
@@ -14,7 +14,7 @@ spec:
   resources:
     requests:
       storage: 5Gi
-  # storageClassName: ""  # 按需指定 StorageClass
+  storageClassName: "local-path"  # 按需指定 StorageClass
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -23,10 +23,18 @@ metadata:
   namespace: promai
 data:
   config.yaml: |
-    # 这里请把config.yaml的内容直接写在这里,或者自定义一个config.yaml文件,然后使用kubectl create configmap命令创建ConfigMap
-    prometheus_url: "http://prometheus.monitoring.svc.cluster.local:9090"
+    # 这里请把 config.yaml 的内容直接写在这里，或者自定义一个 config.yaml 文件后再创建 ConfigMap。
+    # 说明：
+    # 1. 如果这里配置了 metric_types，PromAI 启动时会优先使用 config.yaml，不会执行 SQL 初始化。
+    # 2. 如果这里不配置 metric_types，可以通过下方 promai-bootstrap-sql + PROMAI_IMPORT_SQL_ON_START=true 走 SQL 初始化。
+    prometheus_url: "http://prometheus-k8s.monitoring.svc.cluster.local:9090"
     project_name: "PromAI"
     cron_schedule: "00 08,17 * * *"
+    # 管理后台登录认证
+    auth:
+      username: "admin"
+      password: "promai@2026"
+      jwt_secret: "promai-jwt-secret-change-in-production"
     report_cleanup:
       enabled: true
       max_age: 7
@@ -64,19 +72,25 @@ spec:
     spec:
       containers:
       - name: promai
-        image: kubehan/promai:latest
+        image: promai:v2.0.2
         ports:
         - containerPort: 8091
           name: http
         env:
         - name: PROMAI_DB_PATH
           value: /app/data/promai.db
+        - name: PROMAI_IMPORT_SQL_ON_START
+          value: "true"
+        - name: PROMAI_IMPORT_SQL_FILE
+          value: /app/deploy/sql/metric_types_seed.sql
         - name: PROMETHEUS_URL
-          value: "http://prometheus.monitoring.svc.cluster.local:9090"
+          value: "http://prometheus.monitor.svc.cluster.local:9090"
         - name: TZ
           value: Asia/Shanghai
         - name: EXTERNAL_PORT
           value: '80'
+        - name: REPORT_URL
+          value: "https://your-promai.example.com"
         volumeMounts:
         - name: config
           mountPath: /app/config
@@ -136,7 +150,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-  - host: promai.example.com
+  - host: 
     http:
       paths:
       - path: /

--- a/deploy/sql/metric_types_seed.sql
+++ b/deploy/sql/metric_types_seed.sql
@@ -1,0 +1,1336 @@
+-- Generated from config.yaml metric_types
+BEGIN;
+
+INSERT INTO metric_types (type_name, sort_order, created_at, updated_at)
+SELECT 'L1-基础设施层：硬件设备监控', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+WHERE NOT EXISTS (
+  SELECT 1 FROM metric_types WHERE type_name = 'L1-基础设施层：硬件设备监控'
+);
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'CPU性能状态监控', 'CPU性能状态监控-1h内平均使用率', 'avg_over_time(
+  (
+    100 - avg by(instance, nodename) (irate(node_cpu_seconds_total{mode=''idle''}[5m]) * 100)
+  )[1h:]
+) * on(instance) group_left(nodename) node_uname_info',
+  99, 'greater', '', '%', '{"instance":"实例地址"}',
+  0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L1-基础设施层：硬件设备监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'CPU性能状态监控'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, '机器负载与CPU核心数比率监控', '', '(node_load5/count without (cpu, mode) (node_cpu_seconds_total{mode="system"}))* on(instance) group_left(nodename) (node_uname_info{nodename !~"hadoop.*"})',
+  3, 'greater', '', '倍', '{"instance":"实例地址","nodename":"主机名"}',
+  1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L1-基础设施层：硬件设备监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = '机器负载与CPU核心数比率监控'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, '内存性能状态监控', '', 'avg_over_time((100 - ((node_memory_MemAvailable_bytes * 100)/node_memory_MemTotal_bytes))[1h:]) * on(instance) group_left(nodename) node_uname_info',
+  95, 'greater', '', '%', '{"instance":"实例地址"}',
+  2, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L1-基础设施层：硬件设备监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = '内存性能状态监控'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, '存储设备状态监控', '', '(
+  (
+    (100 - (node_filesystem_avail_bytes * 100 / node_filesystem_size_bytes{mountpoint=~"/home|/mnt.*|/data.*|/opt.*"}))
+    and
+    ON (instance, device, mountpoint) node_filesystem_readonly == 0
+  )
+  * ON (instance) group_left(nodename) node_uname_info
+)',
+  90, 'greater', 'critical', '%', '{"device":"磁盘设备","instance":"实例地址","mountpoint":"盘路径","nodename":"主机名"}',
+  3, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L1-基础设施层：硬件设备监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = '存储设备状态监控'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, '磁盘读写IO性能监控3小时内平均使用率', '磁盘读写IO性能监控-3小时内平均使用率', 'min_over_time((rate(node_disk_io_time_seconds_total{}[5m]) * 100)[3h:5m]) >= 10',
+  95, 'greater', '', '%', '{"device":"磁盘设备","instance":"实例地址","service":"服务名称"}',
+  4, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L1-基础设施层：硬件设备监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = '磁盘读写IO性能监控3小时内平均使用率'
+  );
+
+INSERT INTO inspection_templates (name, description, created_at, updated_at)
+SELECT 'L1-基础设施层：硬件设备监控', '基于「L1-基础设施层：硬件设备监控」自动创建的默认模板', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+WHERE NOT EXISTS (
+  SELECT 1 FROM inspection_templates WHERE name = 'L1-基础设施层：硬件设备监控'
+);
+
+INSERT OR IGNORE INTO inspection_template_metrics (template_id, metric_config_id)
+SELECT t.id, mc.id
+FROM inspection_templates t
+JOIN metric_types mt ON mt.type_name = 'L1-基础设施层：硬件设备监控'
+JOIN metric_configs mc ON mc.metric_type_id = mt.id
+WHERE t.name = 'L1-基础设施层：硬件设备监控';
+
+INSERT INTO metric_types (type_name, sort_order, created_at, updated_at)
+SELECT 'L2-网络层：网络连接监控', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+WHERE NOT EXISTS (
+  SELECT 1 FROM metric_types WHERE type_name = 'L2-网络层：网络连接监控'
+);
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, '网络丢包率监控', '', 'rate(node_network_receive_drop_total{device!~"cal.*"}[5m])',
+  100, 'greater', '', '', '{"instance":"实例地址"}',
+  0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L2-网络层：网络连接监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = '网络丢包率监控'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, '网络连接负载监控', '', 'node_netstat_Tcp_CurrEstab{}',
+  30000, 'greater', 'critical', '', '{"instance":"实例地址"}',
+  1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L2-网络层：网络连接监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = '网络连接负载监控'
+  );
+
+INSERT INTO inspection_templates (name, description, created_at, updated_at)
+SELECT 'L2-网络层：网络连接监控', '基于「L2-网络层：网络连接监控」自动创建的默认模板', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+WHERE NOT EXISTS (
+  SELECT 1 FROM inspection_templates WHERE name = 'L2-网络层：网络连接监控'
+);
+
+INSERT OR IGNORE INTO inspection_template_metrics (template_id, metric_config_id)
+SELECT t.id, mc.id
+FROM inspection_templates t
+JOIN metric_types mt ON mt.type_name = 'L2-网络层：网络连接监控'
+JOIN metric_configs mc ON mc.metric_type_id = mt.id
+WHERE t.name = 'L2-网络层：网络连接监控';
+
+INSERT INTO metric_types (type_name, sort_order, created_at, updated_at)
+SELECT 'L3-容器层：K8s运行环境核心服务监控', 2, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+WHERE NOT EXISTS (
+  SELECT 1 FROM metric_types WHERE type_name = 'L3-容器层：K8s运行环境核心服务监控'
+);
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'K8s Node 节点状态检查', 'Node 节点状态异常或宕机', 'kube_node_status_condition{job="kube-state-metrics",condition="Ready",status="true"}  * on(node) group_left(label_hostname) (kube_node_labels{})',
+  1, 'equal', 'normal', '', '{"instance":"实例地址","node":"主机名"}',
+  0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L3-容器层：K8s运行环境核心服务监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'K8s Node 节点状态检查'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'K8s 基础组件健康状态检查', 'K8s 基础组件健康状态检查', 'up{job=~"kube.*"}',
+  1, 'equal', 'normal', '', '{"instance":"实例地址","service":"组件名称"}',
+  1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L3-容器层：K8s运行环境核心服务监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'K8s 基础组件健康状态检查'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, '集群核心网关服务状态监控--自定义监控建设中', 'K8s集群关键服务状态统计', 'key_pod_status',
+  1, 'equal', 'normal', '', '{"component":"服务名称","describe":"服务描述","hostname":"主机名称","owner":"负责人"}',
+  2, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L3-容器层：K8s运行环境核心服务监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = '集群核心网关服务状态监控--自定义监控建设中'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, '系统关键Pod运行状态监控', '系统关键Pod运行状态监控', 'kube_pod_status_ready{condition="false",namespace=~"kube-system|.*prod.*|.*infra.*|.*es.*|monitoring|kong|proxy|loki",pod !~".*backup.*"}',
+  0, 'equal', 'normal', '', '{"condition":"状态","namespace":"命名空间","pod":"服务名称"}',
+  3, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L3-容器层：K8s运行环境核心服务监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = '系统关键Pod运行状态监控'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, '分布式存储etcd状态监控', '分布式存储etcd状态监控', 'routing_etcd_node_status',
+  1, 'equal', 'normal', '', '{"component":"服务组件","describe":"描述","hostname":"主机名称","owner":"负责人","target":"线上 or 线下"}',
+  4, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L3-容器层：K8s运行环境核心服务监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = '分布式存储etcd状态监控'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'DNS服务响应性能监控', 'DNS服务响应性能监控', 'histogram_quantile(0.99,sum(rate(coredns_dns_request_duration_seconds_bucket{}[5m])) by(le,job,instance,pod))',
+  2, 'greater', '', 's', '{"instance":"实例地址","job":"服务名","pod":"DNS服务节点"}',
+  5, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L3-容器层：K8s运行环境核心服务监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'DNS服务响应性能监控'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, '容器CPU资源使用监控-1小时内平均使用率', '容器CPU资源使用监控', '100 *  avg_over_time(
+  (
+    sum by(container, namespace, pod) (
+      rate(container_cpu_usage_seconds_total{
+        container!="",
+        namespace !~ ".*preview.*"
+      }[5m])
+    )
+    /
+    sum by(container, namespace, pod) (
+      kube_pod_container_resource_limits{
+        container!="",
+        resource="cpu",
+        namespace !~ ".*preview.*"
+      }
+    )
+  )[1h:]
+) > 80',
+  95, 'greater', '', '%', '{"namespace":"命名空间","pod":"服务名称"}',
+  6, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L3-容器层：K8s运行环境核心服务监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = '容器CPU资源使用监控-1小时内平均使用率'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, '容器内存资源使用监控-1小时内平均使用率', '容器内存资源使用监控', '100 *  avg_over_time( (
+  sum by(container, namespace, pod) (
+    container_memory_working_set_bytes{
+      container!="",
+      container!="POD",
+      namespace !~ ".*preview.*"
+    }
+  )
+  /
+  sum by(container, namespace, pod) (
+    kube_pod_container_resource_limits{
+      container!="",
+      container!="POD",
+      resource="memory",
+      namespace !~ ".*preview.*"
+    }
+  )
+)[1h:] ) > 80',
+  95, 'greater', '', '%', '{"namespace":"命名空间","pod":"服务名称"}',
+  7, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L3-容器层：K8s运行环境核心服务监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = '容器内存资源使用监控-1小时内平均使用率'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, '接入层路由服务健康监控', '接入层路由服务健康监控', 'haproxy_up{service="routing-exporter"}',
+  1, 'equal', 'normal', '', '{"hostname":"主机名称","instance":"实例地址","pod":"服务名称"}',
+  8, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L3-容器层：K8s运行环境核心服务监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = '接入层路由服务健康监控'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, '节点Pod资源数量使用负载监控', '节点Pod资源使用负载监控', 'count by(cluster, node) (
+  (kube_pod_status_phase{job="kube-state-metrics", phase="Running"} == 1)
+  * on(instance, pod, namespace, cluster) group_left(node)
+  kube_pod_info{job="kube-state-metrics"}
+) / max by(cluster, node) (
+  kube_node_status_capacity{job="kube-state-metrics", resource="pods"}
+) > 0',
+  95, 'greater', '', '%', '{"node":"主机名"}',
+  9, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L3-容器层：K8s运行环境核心服务监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = '节点Pod资源数量使用负载监控'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'P90用户中心who接口5分钟内平均响应时长大于5s 告警', 'P90用户中心who接口5分钟内平均响应时长大于5s 告警', 'histogram_quantile(
+  0.9,
+  sum(rate(user_who_response_latency_seconds_bucket[5m]))
+    by (namespace, container, exported_endpoint, instance, le)
+)',
+  10, 'greater', '', '', '{"exported_endpoint":"url","namespace":"命名空间"}',
+  10, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L3-容器层：K8s运行环境核心服务监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'P90用户中心who接口5分钟内平均响应时长大于5s 告警'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, ' P90用户中心cas登录接口5分钟内平均响应时长大于5s 告警', ' P90用户中心cas登录接口5分钟内平均响应时长大于5s 告警', 'histogram_quantile(
+  0.9,
+  sum(rate(cas_js_login_response_latency_seconds_bucket[5m]))
+    by (namespace, container, exported_endpoint, instance, le)
+)',
+  10, 'greater', '', '', '{"exported_endpoint":"url","namespace":"命名空间"}',
+  11, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L3-容器层：K8s运行环境核心服务监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = ' P90用户中心cas登录接口5分钟内平均响应时长大于5s 告警'
+  );
+
+INSERT INTO inspection_templates (name, description, created_at, updated_at)
+SELECT 'L3-容器层：K8s运行环境核心服务监控', '基于「L3-容器层：K8s运行环境核心服务监控」自动创建的默认模板', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+WHERE NOT EXISTS (
+  SELECT 1 FROM inspection_templates WHERE name = 'L3-容器层：K8s运行环境核心服务监控'
+);
+
+INSERT OR IGNORE INTO inspection_template_metrics (template_id, metric_config_id)
+SELECT t.id, mc.id
+FROM inspection_templates t
+JOIN metric_types mt ON mt.type_name = 'L3-容器层：K8s运行环境核心服务监控'
+JOIN metric_configs mc ON mc.metric_type_id = mt.id
+WHERE t.name = 'L3-容器层：K8s运行环境核心服务监控';
+
+INSERT INTO metric_types (type_name, sort_order, created_at, updated_at)
+SELECT 'L4-中间件层：MongoDB数据库监控', 3, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+WHERE NOT EXISTS (
+  SELECT 1 FROM metric_types WHERE type_name = 'L4-中间件层：MongoDB数据库监控'
+);
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'MongoDB副本集节点状态监控', 'MongoDB副本集节点状态监控', 'mongodb_replset_member_health',
+  1, 'not_equal', '', '', '{"job":"采集器名称","name":"服务地址"}',
+  0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L4-中间件层：MongoDB数据库监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'MongoDB副本集节点状态监控'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'MongoDB复制延迟监控', 'MongoDB副本复制延迟监控', 'mongodb_mongod_replset_member_replication_lag or mongodb_replset_member_state',
+  60, 'greater', '', 's', '{"job":"采集器名称","name":"服务地址"}',
+  1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L4-中间件层：MongoDB数据库监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'MongoDB复制延迟监控'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'MongoDB逻辑会话数监控', 'MongoDB逻辑会话数监控', 'mongodb_sessions_active_total OR mongodb_shard_active_sessions OR mongodb_rs_session_count',
+  800000, 'greater', '', '', '{"instance":"主机地址","job":"采集器名称","shard":"分片信息"}',
+  2, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L4-中间件层：MongoDB数据库监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'MongoDB逻辑会话数监控'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'MongoDB连接数监控', 'MongoDB连接数使用率监控', 'avg by (instance) (mongodb_connections{state="current"}) / avg by (instance) (mongodb_connections{state="available"}) * 100',
+  80, 'greater', '', '%', '{"instance":"实例地址"}',
+  3, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L4-中间件层：MongoDB数据库监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'MongoDB连接数监控'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'MongoDB内存使用率', 'MongoDB内存使用率监控', '(max by(container, pod, node) (container_memory_working_set_bytes{container!="",container!="POD",pod=~".*mongo.*"}) / max by(container, pod, node) (kube_pod_container_resource_limits{container!="",container!="POD",pod=~".*mongo.*",resource="memory"})) * 100',
+  95, 'greater_equal', '', '%', '{"container":"实例地址","pod":"pod信息"}',
+  4, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L4-中间件层：MongoDB数据库监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'MongoDB内存使用率'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'MongoDB性能监控', 'MongoDB增删改查性能监控', 'mongodb_crud_time_ms or mongodb_operation_duration_seconds',
+  3, 'greater_equal', '', '', '{"instance":"主机地址","operation":"具体操作类型","shard":"副本信息"}',
+  5, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L4-中间件层：MongoDB数据库监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'MongoDB性能监控'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'MongoDB网络流量', 'MongoDB网络流量监控', 'rate(mongodb_network_bytes_total[1m])',
+  1e+07, 'greater', '', '', '{"instance":"实例地址","pod":"pod信息","service":"分片信息","state":"流量状态"}',
+  6, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L4-中间件层：MongoDB数据库监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'MongoDB网络流量'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'MongoDB服务宕机', 'MongoDB服务宕机监控', 'mongodb_up',
+  0, 'equal', '', '', '{"instance":"实例地址","job":"分片信息","pod":"pod信息"}',
+  7, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L4-中间件层：MongoDB数据库监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'MongoDB服务宕机'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'MongoDB实例发生重启', 'MongoDB重启监控', 'mongodb_instance_uptime_seconds',
+  60, 'less', '', '', '{"instance":"实例地址","pod":"pod信息","service":"分片信息"}',
+  8, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L4-中间件层：MongoDB数据库监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'MongoDB实例发生重启'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'MongoDB断言告警 - 需要立即检查', 'MongoDB数据损坏风险监控', 'rate(mongodb_asserts_total{type=~"regular|message"}[5m])',
+  0, 'equal', 'normal', '', '{"instance":"实例信息","pod":"pod信息","service":"分片信息","type":"状态类型"}',
+  9, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L4-中间件层：MongoDB数据库监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'MongoDB断言告警 - 需要立即检查'
+  );
+
+INSERT INTO inspection_templates (name, description, created_at, updated_at)
+SELECT 'L4-中间件层：MongoDB数据库监控', '基于「L4-中间件层：MongoDB数据库监控」自动创建的默认模板', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+WHERE NOT EXISTS (
+  SELECT 1 FROM inspection_templates WHERE name = 'L4-中间件层：MongoDB数据库监控'
+);
+
+INSERT OR IGNORE INTO inspection_template_metrics (template_id, metric_config_id)
+SELECT t.id, mc.id
+FROM inspection_templates t
+JOIN metric_types mt ON mt.type_name = 'L4-中间件层：MongoDB数据库监控'
+JOIN metric_configs mc ON mc.metric_type_id = mt.id
+WHERE t.name = 'L4-中间件层：MongoDB数据库监控';
+
+INSERT INTO metric_types (type_name, sort_order, created_at, updated_at)
+SELECT 'L4-中间件层：MySQL数据库监控', 4, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+WHERE NOT EXISTS (
+  SELECT 1 FROM metric_types WHERE type_name = 'L4-中间件层：MySQL数据库监控'
+);
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'MySQL连接数', 'MySQL连接数使用率监控', 'avg by (instance) (mysql_global_status_threads_connected) / avg by (instance) (mysql_global_variables_max_connections) * 100',
+  80, 'greater', '', '%', '{"instance":"实例地址"}',
+  0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L4-中间件层：MySQL数据库监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'MySQL连接数'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'MySQL thread running监控', 'MySQL并发监控', 'mysql_global_status_threads_running',
+  50, 'greater', '', '', '{"instance":"实例地址","service":"服务名"}',
+  1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L4-中间件层：MySQL数据库监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'MySQL thread running监控'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'MySQL活跃线程异常增长', 'MySQL活跃线程异常增长监控', 'rate(mysql_global_status_threads_created[5m])',
+  10, 'greater', '', '', '{"instance":"实例地址","job":"采集器名称"}',
+  2, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L4-中间件层：MySQL数据库监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'MySQL活跃线程异常增长'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'MySQL主从复制错误', 'MySQL主从复制错误监控', 'mysql_slave_status_last_io_errno',
+  0, 'not_equal', '', '', '{"instance":"实例地址","job":"采集器名称","master_host":"mysql主库地址"}',
+  3, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L4-中间件层：MySQL数据库监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'MySQL主从复制错误'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'MySQL SLAVE SQL线程停止', 'MySQL SLAVE SQL线程停止监控', 'mysql_slave_status_master_server_id > 0 and ON (instance) mysql_slave_status_slave_sql_running',
+  0, 'equal', '', '', '{"instance":"实例地址","job":"采集器名称","master_host":"mysql主库地址"}',
+  4, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L4-中间件层：MySQL数据库监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'MySQL SLAVE SQL线程停止'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'MySQL慢查询监控', 'MySQL慢查询数量监控', 'increase(mysql_global_status_slow_queries[1m])',
+  150, 'greater', '', '', '{"instance":"实例地址","service":"服务名"}',
+  5, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L4-中间件层：MySQL数据库监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'MySQL慢查询监控'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'MySQL打开文件数监控', 'MySQL打开文件数监控', 'avg by (instance) (mysql_global_status_innodb_num_open_files) / avg by (instance)(mysql_global_variables_open_files_limit) * 100',
+  80, 'greater', '', '%', '{"instance":"实例地址"}',
+  6, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L4-中间件层：MySQL数据库监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'MySQL打开文件数监控'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'MySQL InnoDB缓冲池命中率', 'MySQL InnoDB缓冲池命中率监控', '(1 - mysql_global_status_innodb_buffer_pool_reads / mysql_global_status_innodb_buffer_pool_read_requests) * 100',
+  95, 'less', 'critical', '%', '{"instance":"实例地址","job":"采集器名称"}',
+  7, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L4-中间件层：MySQL数据库监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'MySQL InnoDB缓冲池命中率'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'MySQL临时表创建频繁', 'MySQL临时表创建频繁监控', 'rate(mysql_global_status_created_tmp_disk_tables[5m]) ',
+  100, 'greater', '', '', '{"instance":"实例地址","job":"采集器名称"}',
+  8, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L4-中间件层：MySQL数据库监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'MySQL临时表创建频繁'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'MySQL连接错误率', 'MySQL连接错误率监控', 'rate(mysql_global_status_connection_errors_total[2m])  ',
+  10, 'greater', '', '', '{"instance":"实例地址","job":"采集器名称"}',
+  9, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L4-中间件层：MySQL数据库监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'MySQL连接错误率'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'MySQL服务宕机', 'MySQL服务宕机监控', 'mysql_up',
+  0, 'equal', '', '', '{"instance":"实例地址","job":"采集器名称"}',
+  10, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L4-中间件层：MySQL数据库监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'MySQL服务宕机'
+  );
+
+INSERT INTO inspection_templates (name, description, created_at, updated_at)
+SELECT 'L4-中间件层：MySQL数据库监控', '基于「L4-中间件层：MySQL数据库监控」自动创建的默认模板', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+WHERE NOT EXISTS (
+  SELECT 1 FROM inspection_templates WHERE name = 'L4-中间件层：MySQL数据库监控'
+);
+
+INSERT OR IGNORE INTO inspection_template_metrics (template_id, metric_config_id)
+SELECT t.id, mc.id
+FROM inspection_templates t
+JOIN metric_types mt ON mt.type_name = 'L4-中间件层：MySQL数据库监控'
+JOIN metric_configs mc ON mc.metric_type_id = mt.id
+WHERE t.name = 'L4-中间件层：MySQL数据库监控';
+
+INSERT INTO metric_types (type_name, sort_order, created_at, updated_at)
+SELECT 'L4-中间件层：Redis缓存服务监控', 5, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+WHERE NOT EXISTS (
+  SELECT 1 FROM metric_types WHERE type_name = 'L4-中间件层：Redis缓存服务监控'
+);
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'Redis服务状态', 'Redis实例运行状态监控', 'redis_up{job!~".*sentinel.*"}',
+  1, 'equal', 'normal', '', '{"instance":"实例地址","service":"采集器命名"}',
+  0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L4-中间件层：Redis缓存服务监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'Redis服务状态'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'Redis连接数', 'Redis连接数使用率监控', '(redis_connected_clients / redis_config_maxclients) * 100',
+  80, 'greater', '', '%', '{"instance":"实例地址","service":"采集器命名"}',
+  1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L4-中间件层：Redis缓存服务监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'Redis连接数'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'Redis内存使用', 'Redis内存使用率监控', 'redis_memory_used_bytes / redis_memory_max_bytes',
+  0.8, 'greater', '', '%', '{"instance":"实例地址","service":"采集器命名"}',
+  2, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L4-中间件层：Redis缓存服务监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'Redis内存使用'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'Redis内存碎片', 'Redis内存碎片率监控', 'redis_memory_used_rss_bytes/redis_memory_used_bytes',
+  2.5, 'greater', '', '', '{"instance":"实例地址","service":"采集器命名"}',
+  3, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L4-中间件层：Redis缓存服务监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'Redis内存碎片'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'Redis慢查询', 'Redis慢查询数量监控', 'rate(redis_slowlog_length[5m])',
+  50, 'greater', '', '', '{"instance":"实例地址","service":"采集器命名"}',
+  4, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L4-中间件层：Redis缓存服务监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'Redis慢查询'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'Redis主从延迟', 'Redis主从同步延迟监控', 'redis_connected_slave_lag_seconds',
+  10, 'greater', '', '', '{"instance":"实例地址","service":"采集器命名","slave_ip":"服务地址","slave_port":"服务端口"}',
+  5, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L4-中间件层：Redis缓存服务监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'Redis主从延迟'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'Redis主从切换', 'Redis主从角色切换监控', 'changes(redis_instance_info{role="master"}[1m])',
+  0, 'greater', 'critical', '', '{"instance":"实例地址","redis_version":"redis版本号","service":"采集器命名"}',
+  6, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L4-中间件层：Redis缓存服务监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'Redis主从切换'
+  );
+
+INSERT INTO inspection_templates (name, description, created_at, updated_at)
+SELECT 'L4-中间件层：Redis缓存服务监控', '基于「L4-中间件层：Redis缓存服务监控」自动创建的默认模板', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+WHERE NOT EXISTS (
+  SELECT 1 FROM inspection_templates WHERE name = 'L4-中间件层：Redis缓存服务监控'
+);
+
+INSERT OR IGNORE INTO inspection_template_metrics (template_id, metric_config_id)
+SELECT t.id, mc.id
+FROM inspection_templates t
+JOIN metric_types mt ON mt.type_name = 'L4-中间件层：Redis缓存服务监控'
+JOIN metric_configs mc ON mc.metric_type_id = mt.id
+WHERE t.name = 'L4-中间件层：Redis缓存服务监控';
+
+INSERT INTO metric_types (type_name, sort_order, created_at, updated_at)
+SELECT 'L4-中间件层：PostgreSQL数据库监控', 6, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+WHERE NOT EXISTS (
+  SELECT 1 FROM metric_types WHERE type_name = 'L4-中间件层：PostgreSQL数据库监控'
+);
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'PostgreSQL服务状态监控-建设中', 'PostgreSQL服务运行状态监控', 'absent(up{job=~"pgsql"})',
+  1, 'equal', '', '', '{"instance":"实例地址","job":"采集器名称"}',
+  0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L4-中间件层：PostgreSQL数据库监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'PostgreSQL服务状态监控-建设中'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'PostgreSQL连接数监控', 'PostgreSQL连接数负载监控', 'pg_stat_activity_count',
+  1500, 'greater_equal', '', '', '{"instance":"实例地址","job":"采集器名称","server":"服务地址","state":"state"}',
+  1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L4-中间件层：PostgreSQL数据库监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'PostgreSQL连接数监控'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'PostgreSQL主从延迟监控', 'PostgreSQL主从同步延迟监控', 'pg_replication_lag_seconds',
+  60, 'greater', '', '', '{"instance":"实例地址","job":"采集器名称","pod":"pod命名"}',
+  2, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L4-中间件层：PostgreSQL数据库监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'PostgreSQL主从延迟监控'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'PostgreSQL长事务监控', 'PostgreSQL长事务数监控', 'pg_up',
+  1, 'greater', '', '', '{"instance":"实例地址","job":"采集器名称","pod":"pod命名","server":"服务地址","state":"state"}',
+  3, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L4-中间件层：PostgreSQL数据库监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'PostgreSQL长事务监控'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'PostgreSQL死锁监控', 'PostgreSQL数据库死锁监控', 'rate(pg_stat_database_deadlocks[30m])',
+  5, 'greater', '', '', '{"instance":"实例地址","job":"采集器名称","pod":"pod命名"}',
+  4, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L4-中间件层：PostgreSQL数据库监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'PostgreSQL死锁监控'
+  );
+
+INSERT INTO inspection_templates (name, description, created_at, updated_at)
+SELECT 'L4-中间件层：PostgreSQL数据库监控', '基于「L4-中间件层：PostgreSQL数据库监控」自动创建的默认模板', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+WHERE NOT EXISTS (
+  SELECT 1 FROM inspection_templates WHERE name = 'L4-中间件层：PostgreSQL数据库监控'
+);
+
+INSERT OR IGNORE INTO inspection_template_metrics (template_id, metric_config_id)
+SELECT t.id, mc.id
+FROM inspection_templates t
+JOIN metric_types mt ON mt.type_name = 'L4-中间件层：PostgreSQL数据库监控'
+JOIN metric_configs mc ON mc.metric_type_id = mt.id
+WHERE t.name = 'L4-中间件层：PostgreSQL数据库监控';
+
+INSERT INTO metric_types (type_name, sort_order, created_at, updated_at)
+SELECT 'L5-接入层：API网关代理监控', 7, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+WHERE NOT EXISTS (
+  SELECT 1 FROM metric_types WHERE type_name = 'L5-接入层：API网关代理监控'
+);
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, '接入层apirouter状态码监控', '接入层apirouter 5xx状态码监控', 'sum(rate(kong_http_status{job="apirouter-exporter",code=~"5..", exported_service!~".*preview.*"}[10m])) by (exported_service) / sum(rate(kong_http_status{job="apirouter-exporter"}[10m])) by (exported_service)',
+  5, 'greater_equal', '', '', '{"exported_service":"服务名称"}',
+  0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L5-接入层：API网关代理监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = '接入层apirouter状态码监控'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'Routing路由状态监控', 'Routing服务健康状态监控', 'haproxy_up',
+  1, 'equal', 'normal', '', '{"instance":"主机地址","namespace":"命名空间","pod":"服务名称"}',
+  1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L5-接入层：API网关代理监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'Routing路由状态监控'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, '接入层Routing后端服务5分钟内平均响应时间', '接入层Routing后端服务5分钟内平均响应时间', 'avg_over_time(haproxy_server_http_response_time_average_seconds{backend !~"modtunnel|sreldap|databus-prod-17", namespace="marathon-prod"}[10m]) > 0.001',
+  10, 'greater_equal', '', 's', '{"backend":"后端服务名称","hostname":"主机地址","namespace":"命名空间","server":"服务名称"}',
+  2, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L5-接入层：API网关代理监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = '接入层Routing后端服务5分钟内平均响应时间'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, '接入层5xx异常状态码监控', '接入层状态码监控', '(sum(rate(nginx_ingress_controller_requests{status=~"5..",namespace!~".*preview.*"}[10m])) by (ingress, exported_service) / sum(rate(nginx_ingress_controller_requests{namespace!~".*preview.*"}[10m])) by (ingress, exported_service) ) * 100 >= 0',
+  5, 'greater_equal', '', '', '{"exported_service":"服务名称","ingress":"ingress名称"}',
+  3, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L5-接入层：API网关代理监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = '接入层5xx异常状态码监控'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'Web服务状态监控', 'Nginx Web服务状态监控-自定义监控建设中', 'network_port_status{process="nginx"}',
+  1, 'equal', 'normal', '', '{"instance":"主机地址","port":"80","process":"服务名称","src_host":"主机名"}',
+  4, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L5-接入层：API网关代理监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'Web服务状态监控'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'OpenAPI服务状态监控', 'OpenAPI接口服务状态监控-自定义监控建设中', 'openapi_status{target="prod",component="openapi"}',
+  1, 'equal', 'normal', '', '{"instance":"实例地址"}',
+  5, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L5-接入层：API网关代理监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'OpenAPI服务状态监控'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'LDAP服务状态监控', 'LDAP认证服务状态监控-自定义监控建设中', 'ldap_server_status{hostname=~"web1.*"}',
+  1, 'equal', 'normal', '', '{"component":"服务名","hostname":"主机名","instance":"实例地址"}',
+  6, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L5-接入层：API网关代理监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'LDAP服务状态监控'
+  );
+
+INSERT INTO inspection_templates (name, description, created_at, updated_at)
+SELECT 'L5-接入层：API网关代理监控', '基于「L5-接入层：API网关代理监控」自动创建的默认模板', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+WHERE NOT EXISTS (
+  SELECT 1 FROM inspection_templates WHERE name = 'L5-接入层：API网关代理监控'
+);
+
+INSERT OR IGNORE INTO inspection_template_metrics (template_id, metric_config_id)
+SELECT t.id, mc.id
+FROM inspection_templates t
+JOIN metric_types mt ON mt.type_name = 'L5-接入层：API网关代理监控'
+JOIN metric_configs mc ON mc.metric_type_id = mt.id
+WHERE t.name = 'L5-接入层：API网关代理监控';
+
+INSERT INTO metric_types (type_name, sort_order, created_at, updated_at)
+SELECT 'L6-应用层：业务服务监控', 8, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+WHERE NOT EXISTS (
+  SELECT 1 FROM metric_types WHERE type_name = 'L6-应用层：业务服务监控'
+);
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, '文件上传服务监控', '文件上传服务状态监控-建设中', 'itmp_coreapi_status',
+  1, 'equal', 'normal', '', '{"component":"服务名","hostname":"主机名","instance":"地址","owner":"负责人"}',
+  0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L6-应用层：业务服务监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = '文件上传服务监控'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, 'CMDB服务状态监控', 'CMDB服务状态监控-自定义监控建设中', 'cmdb_status',
+  1, 'equal', 'normal', '', '{"component":"服务名","hostname":"主机名","instance":"地址","owner":"负责人"}',
+  1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L6-应用层：业务服务监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = 'CMDB服务状态监控'
+  );
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, '业务核心服务监控采集检查', '核心服务监控覆盖检查', 'up{job=~".*eventlog.*|.*passport.*|.*ucenter.*",namespace!~".*preview.*|.*ingress.*"}',
+  1, 'equal', 'normal', '', '{"instance":"地址","job":"服务对应exporter命名","namespace":"命名空间","service":"服务名"}',
+  2, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L6-应用层：业务服务监控'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = '业务核心服务监控采集检查'
+  );
+
+INSERT INTO inspection_templates (name, description, created_at, updated_at)
+SELECT 'L6-应用层：业务服务监控', '基于「L6-应用层：业务服务监控」自动创建的默认模板', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+WHERE NOT EXISTS (
+  SELECT 1 FROM inspection_templates WHERE name = 'L6-应用层：业务服务监控'
+);
+
+INSERT OR IGNORE INTO inspection_template_metrics (template_id, metric_config_id)
+SELECT t.id, mc.id
+FROM inspection_templates t
+JOIN metric_types mt ON mt.type_name = 'L6-应用层：业务服务监控'
+JOIN metric_configs mc ON mc.metric_type_id = mt.id
+WHERE t.name = 'L6-应用层：业务服务监控';
+
+INSERT INTO metric_types (type_name, sort_order, created_at, updated_at)
+SELECT 'L7-采集层：监控数据采集状态', 9, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+WHERE NOT EXISTS (
+  SELECT 1 FROM metric_types WHERE type_name = 'L7-采集层：监控数据采集状态'
+);
+
+INSERT INTO metric_configs (
+  metric_type_id, datasource_id, name, description, query,
+  threshold, threshold_type, threshold_status, unit, labels_json,
+  sort_order, created_at, updated_at
+)
+SELECT mt.id, NULL, '监控数据采集状态监控', 'Exporter数据采集服务状态监控', 'up{job!~"hive.*|hadoop.*|hbase.*|spark.*|yarn.*|.*kafka.*"} ',
+  1, 'equal', 'normal', '', '{"instance":"地址","job":"服务对应exporter命名","service":"服务名"}',
+  0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM metric_types mt
+WHERE mt.type_name = 'L7-采集层：监控数据采集状态'
+  AND NOT EXISTS (
+    SELECT 1 FROM metric_configs mc
+    WHERE mc.metric_type_id = mt.id
+      AND mc.datasource_id IS NULL
+      AND mc.name = '监控数据采集状态监控'
+  );
+
+INSERT INTO inspection_templates (name, description, created_at, updated_at)
+SELECT 'L7-采集层：监控数据采集状态', '基于「L7-采集层：监控数据采集状态」自动创建的默认模板', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+WHERE NOT EXISTS (
+  SELECT 1 FROM inspection_templates WHERE name = 'L7-采集层：监控数据采集状态'
+);
+
+INSERT OR IGNORE INTO inspection_template_metrics (template_id, metric_config_id)
+SELECT t.id, mc.id
+FROM inspection_templates t
+JOIN metric_types mt ON mt.type_name = 'L7-采集层：监控数据采集状态'
+JOIN metric_configs mc ON mc.metric_type_id = mt.id
+WHERE t.name = 'L7-采集层：监控数据采集状态';
+
+INSERT INTO inspection_templates (name, description, created_at, updated_at)
+SELECT '全局模板', '包含全部全局指标的默认模板', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+WHERE NOT EXISTS (
+  SELECT 1 FROM inspection_templates WHERE name = '全局模板'
+);
+
+INSERT OR IGNORE INTO inspection_template_metrics (template_id, metric_config_id)
+SELECT t.id, mc.id
+FROM inspection_templates t
+JOIN metric_configs mc ON mc.metric_type_id IS NOT NULL
+WHERE t.name = '全局模板';
+
+COMMIT;

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -49,7 +49,12 @@ export const updateDataSource = (id: number, d: Partial<DataSource>) => api.put<
 export const deleteDataSource = (id: number) => api.delete(`/datasources/${id}`)
 export const batchDeleteDataSources = (ids: number[]) => api.patch('/datasources', { ids, action: 'delete' })
 export const batchToggleDataSources = (ids: number[], enabled: boolean) => api.patch('/datasources', { ids, action: 'toggle', enabled })
-export const batchSetTemplate = (ids: number[], templateId: number | null) => api.patch('/datasources', { ids, action: 'set-template', template_id: templateId })
+export const batchSetTemplate = (ids: number[], templateIds: number[]) => api.patch('/datasources', {
+  ids,
+  action: 'set-template',
+  template_ids: templateIds,
+  template_id: templateIds[0] ?? null,
+})
 export const batchSetNotify = (ids: number[], notifyChannels: string) => api.patch('/datasources', { ids, action: 'set-notify', notify_channels: notifyChannels })
 export const batchApplyTemplate = (ids: number[]) => api.patch('/datasources', { ids, action: 'apply-template' })
 export const batchInspect = (ids: number[]) => api.patch('/datasources', { ids, action: 'inspect' })
@@ -120,6 +125,7 @@ export const getSyncLogs = (id: number) => api.get<SyncLog[]>(`/sync-sources/${i
 export const getTemplates = (params?: { page?: number; page_size?: number; keyword?: string }) =>
   api.get<{ items: any[]; total: number; page: number; page_size: number }>('/templates', { params })
 export const getAllTemplates = () => api.get<any[]>('/templates/all')
+export const initTemplates = () => api.post('/templates/init')
 export const getTemplate = (id: number) => api.get(`/templates/${id}`)
 export const createTemplate = (name: string, description?: string) => api.post('/templates', { name, description })
 export const updateTemplate = (id: number, t: any) => api.put(`/templates/${id}`, t)

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -7,9 +7,16 @@ export interface DataSource {
   is_default?: boolean
   enabled?: boolean
   template_id?: number | null
+  template_ids?: number[]
+  project_name?: string
   notify_channels?: string
   created_at?: string
+  updated_at?: string
   health_status?: string
+  connection_status?: string
+  connection_checked_at?: string | null
+  report_status?: string
+  last_report_at?: string | null
 }
 
 export interface MetricConfig {

--- a/frontend/src/views/AiChat.vue
+++ b/frontend/src/views/AiChat.vue
@@ -3,13 +3,14 @@
     <div class="page-header">
       <h2><el-icon><MagicStick /></el-icon> AI 智能助手</h2>
       <div class="header-controls">
-        <p>自然语言查询指标、分析告警、管理系统</p>
+        <p>{{ currentSessionTitle || '自然语言查询指标、分析告警、管理系统' }}</p>
         <div class="model-selector" v-if="modelOptions.length > 0">
           <span class="model-label">当前模型：</span>
           <el-select v-model="currentModel" size="small" style="width: 180px;">
             <el-option v-for="m in modelOptions" :key="m.name" :label="m.name" :value="m.name" />
           </el-select>
         </div>
+        <el-button plain size="small" @click="startNewSession">新建会话</el-button>
       </div>
     </div>
 
@@ -87,12 +88,15 @@
       </div>
 
       <div class="chat-sidebar" v-if="sessions.length > 0">
-        <div class="sidebar-title">历史会话</div>
+        <div class="sidebar-title-row">
+          <div class="sidebar-title">历史会话</div>
+          <el-button text size="small" @click="startNewSession">新建会话</el-button>
+        </div>
         <div v-for="s in sessions" :key="s.id" class="session-item" @click="switchSession(s.id)">
           <el-icon :size="14"><ChatDotRound /></el-icon>
           <div class="session-info">
-            <span class="session-name">{{ s.model_name || shortId(s.id) }}</span>
-            <span class="session-meta">{{ s.msg_count }} 条消息</span>
+            <span class="session-name">{{ s.title || s.model_name || shortId(s.id) }}</span>
+            <span class="session-meta">{{ s.msg_count }} 条消息 · {{ s.model_name || '未命名模型' }}</span>
           </div>
           <el-button text size="small" @click.stop="deleteSession(s.id)">
             <el-icon :size="12"><Close /></el-icon>
@@ -104,7 +108,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, nextTick } from 'vue'
+import { computed, ref, onMounted, nextTick } from 'vue'
 import { marked } from 'marked'
 import { getAiSessions, deleteAiSession, getSettings } from '../api'
 
@@ -128,10 +132,17 @@ const inputText = ref('')
 const messages = ref<ChatMessage[]>([])
 const loading = ref(false)
 const sessionId = ref('')
-const sessions = ref<{id: string; created_at: string; updated_at: string; msg_count: number; model_name?: string}[]>([])
+const sessions = ref<{id: string; created_at: string; updated_at: string; msg_count: number; model_name?: string; title?: string}[]>([])
 const currentModel = ref('')
 const modelOptions = ref<{name: string}[]>([])
 const chatRef = ref<HTMLElement | null>(null)
+const currentSessionTitle = computed(() => {
+  const current = sessions.value.find(s => s.id === sessionId.value)
+  if (current?.title) return current.title
+  const firstUserMessage = messages.value.find(m => m.role === 'user')?.content?.trim()
+  if (!firstUserMessage) return ''
+  return firstUserMessage.length > 28 ? firstUserMessage.slice(0, 28) + '...' : firstUserMessage
+})
 
 function shortId(id: string) {
   return id.length > 12 ? id.slice(0, 12) + '...' : id
@@ -229,6 +240,12 @@ function sendSuggestion(text: string) {
   sendMessage()
 }
 
+function startNewSession() {
+  sessionId.value = ''
+  messages.value = []
+  inputText.value = ''
+}
+
 function scrollToBottom() {
   nextTick(() => {
     if (chatRef.value) {
@@ -253,6 +270,9 @@ async function switchSession(id: string) {
     })
     if (!res.ok) throw new Error('加载失败')
     const data = await res.json()
+    if (data.model_name) {
+      currentModel.value = data.model_name
+    }
     for (const m of data.messages) {
       messages.value.push({ role: m.role, content: m.content })
     }
@@ -305,6 +325,12 @@ onMounted(() => {
   gap: 16px;
   min-height: 0;
   overflow: hidden;
+}
+
+.sidebar-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .chat-layout {

--- a/frontend/src/views/DataSources.vue
+++ b/frontend/src/views/DataSources.vue
@@ -63,9 +63,10 @@
         <template v-if="batchMode === 'template'">
           <el-form label-width="100px">
             <el-form-item label="巡检模板">
-              <el-select v-model="batchTemplateId" placeholder="不绑定模板" clearable filterable style="width: 100%;">
+              <el-select v-model="batchTemplateIds" multiple placeholder="不绑定模板" clearable filterable style="width: 100%;">
                 <el-option v-for="t in templates" :key="t.id" :label="t.name + ' (' + t.metric_count + ' 指标)'" :value="t.id" />
               </el-select>
+              <div style="font-size: 11px; color: var(--text-tertiary); margin-top: 4px;">可绑定多个模板，按选择顺序合并，后面的模板会覆盖前面同名指标的配置</div>
             </el-form-item>
           </el-form>
         </template>
@@ -121,14 +122,19 @@
             />
           </template>
         </el-table-column>
-        <el-table-column label="健康状态" width="90" align="center">
+        <el-table-column label="健康状态" width="180" align="center">
           <template #default="{ row }">
-            <span v-if="row.health_status === 'online'" style="display: flex; align-items: center; justify-content: center; gap: 4px; color: #10b981; font-size: 13px;">
-              <span style="width: 8px; height: 8px; border-radius: 50%; background: #10b981; box-shadow: 0 0 6px rgba(16,185,129,0.5);"></span>在线
-            </span>
-            <span v-else style="display: flex; align-items: center; justify-content: center; gap: 4px; color: var(--text-tertiary); font-size: 13px;">
-              <span style="width: 8px; height: 8px; border-radius: 50%; background: var(--text-tertiary);"></span>未知
-            </span>
+            <div style="display: flex; flex-direction: column; align-items: flex-start; gap: 4px;">
+              <span :style="healthTextStyle(row.health_status)" style="display: flex; align-items: center; gap: 4px; font-size: 13px;">
+                <span :style="healthDotStyle(row.health_status)"></span>{{ healthLabel(row.health_status) }}
+              </span>
+              <span style="font-size: 11px; color: var(--text-tertiary);">
+                连通: {{ healthLabel(row.connection_status) }}<span v-if="row.connection_checked_at"> · {{ dayjs(row.connection_checked_at).format('MM-DD HH:mm') }}</span>
+              </span>
+              <span style="font-size: 11px; color: var(--text-tertiary);">
+                巡检: {{ healthLabel(row.report_status) }}<span v-if="row.last_report_at"> · {{ dayjs(row.last_report_at).format('MM-DD HH:mm') }}</span>
+              </span>
+            </div>
           </template>
         </el-table-column>
         <el-table-column prop="username" label="用户名" width="100">
@@ -137,10 +143,16 @@
             <span v-else style="color: var(--text-tertiary);">-</span>
           </template>
         </el-table-column>
-        <el-table-column label="巡检模板" width="150">
+        <el-table-column label="巡检模板" min-width="220">
           <template #default="{ row }">
-            <span v-if="row.template_id" style="color: var(--text-secondary); font-size: 13px;">{{ templateName(row.template_id) }}</span>
+            <span v-if="normalizeTemplateIds(row).length" style="color: var(--text-secondary); font-size: 13px;">{{ templateNames(normalizeTemplateIds(row)) }}</span>
             <span v-else style="color: var(--text-tertiary); font-size: 13px;">-</span>
+          </template>
+        </el-table-column>
+        <el-table-column label="项目名称" width="150">
+          <template #default="{ row }">
+            <span v-if="row.project_name" style="color: var(--text-secondary); font-size: 13px;">{{ row.project_name }}</span>
+            <span v-else style="color: var(--text-tertiary); font-size: 13px;">跟随系统设置</span>
           </template>
         </el-table-column>
         <el-table-column label="通知渠道" width="170">
@@ -200,11 +212,14 @@
         <el-form-item label="密码">
           <el-input v-model="form.password" type="password" placeholder="可选" show-password />
         </el-form-item>
+        <el-form-item label="项目名称">
+          <el-input v-model="form.project_name" placeholder="留空则跟随系统设置" />
+        </el-form-item>
         <el-form-item label="巡检模板">
-          <el-select v-model="form.template_id" placeholder="不绑定模板（使用指标列表中的配置）" clearable filterable style="width: 100%;">
+          <el-select v-model="form.template_ids" multiple placeholder="不绑定模板（使用指标列表中的配置）" clearable filterable style="width: 100%;">
             <el-option v-for="t in templates" :key="t.id" :label="t.name + ' (' + t.metric_count + ' 指标)'" :value="t.id" />
           </el-select>
-          <div style="font-size: 11px; color: var(--text-tertiary); margin-top: 2px;">绑定的模板在巡检时优先使用，未绑定时使用「导入全局指标」生成的配置</div>
+          <div style="font-size: 11px; color: var(--text-tertiary); margin-top: 2px;">可绑定多个模板，按选择顺序合并，后面的模板会覆盖前面同名指标的配置</div>
         </el-form-item>
         <el-form-item label="通知渠道">
           <el-select v-model="selectedChannels" multiple placeholder="不发送通知" clearable filterable style="width: 100%;">
@@ -420,7 +435,7 @@ const importVisible = ref(false)
 const editingId = ref<number | null>(null)
 const formRef = ref<FormInstance>()
 const yamlContent = ref('')
-const form = ref<DataSource>({ name: '', url: '', username: '', password: '' })
+const form = ref<DataSource>({ name: '', url: '', username: '', password: '', template_ids: [], project_name: '' })
 const selectedChannels = ref<number[]>([])
 const rules = {
   name: [{ required: true, message: '请输入名称', trigger: 'blur' }],
@@ -437,7 +452,7 @@ const filterHealth = ref('')
 const selectedIds = ref<number[]>([])
 const batchDialogVisible = ref(false)
 const batchMode = ref<'template' | 'notify' | 'creds'>('template')
-const batchTemplateId = ref<number | null>(null)
+const batchTemplateIds = ref<number[]>([])
 const batchNotifyChannels = ref<number[]>([])
 const batchUsername = ref('')
 const batchPassword = ref('')
@@ -573,22 +588,29 @@ function channelNames(json: string) {
   } catch { return '' }
 }
 
-function templateName(id: number | null | undefined) {
-  if (!id) return ''
-  const t = templates.value.find(x => x.id === id)
-  return t ? t.name : `ID: ${id}`
+function normalizeTemplateIds(ds: Partial<DataSource>) {
+  if (Array.isArray(ds.template_ids) && ds.template_ids.length > 0) return ds.template_ids
+  if (ds.template_id) return [ds.template_id]
+  return []
+}
+
+function templateNames(ids: number[]) {
+  return ids.map(id => {
+    const t = templates.value.find(x => x.id === id)
+    return t ? t.name : `ID: ${id}`
+  }).join(' + ')
 }
 
 function openCreate() {
   editingId.value = null
-  form.value = { name: '', url: '', username: '', password: '' }
+  form.value = { name: '', url: '', username: '', password: '', template_ids: [], project_name: '' }
   selectedChannels.value = []
   dialogVisible.value = true
 }
 
 function openEdit(row: DataSource) {
   editingId.value = row.id!
-  form.value = { ...row, password: '' }
+  form.value = { ...row, password: '', template_ids: [...normalizeTemplateIds(row)] }
   selectedChannels.value = row.notify_channels ? JSON.parse(row.notify_channels) : []
   dialogVisible.value = true
 }
@@ -600,6 +622,8 @@ async function handleSave() {
   try {
     const payload = {
       ...form.value,
+      template_ids: normalizeTemplateIds(form.value),
+      template_id: normalizeTemplateIds(form.value)[0] ?? null,
       notify_channels: selectedChannels.value.length ? JSON.stringify(selectedChannels.value) : '',
     }
     if (editingId.value) {
@@ -624,8 +648,30 @@ async function testConnectivity(row: DataSource) {
     } else {
       ElMessage.error(res.data.message || '连接失败')
     }
+    await fetchData()
   } catch (e: any) {
     ElMessage.error(e.message)
+    await fetchData()
+  }
+}
+
+function healthLabel(status?: string) {
+  return status === 'online' ? '在线' : '未知'
+}
+
+function healthTextStyle(status?: string) {
+  return {
+    color: status === 'online' ? '#10b981' : 'var(--text-tertiary)',
+  }
+}
+
+function healthDotStyle(status?: string) {
+  return {
+    width: '8px',
+    height: '8px',
+    borderRadius: '50%',
+    background: status === 'online' ? '#10b981' : 'var(--text-tertiary)',
+    boxShadow: status === 'online' ? '0 0 6px rgba(16,185,129,0.5)' : 'none',
   }
 }
 
@@ -718,7 +764,7 @@ const batchDialogTitle = ref('')
 const batchSaveLabel = ref('')
 function openBatchDialog(mode: 'template' | 'notify' | 'creds') {
   batchMode.value = mode
-  batchTemplateId.value = null
+  batchTemplateIds.value = []
   batchNotifyChannels.value = []
   batchUsername.value = ''
   batchPassword.value = ''
@@ -736,8 +782,8 @@ async function handleBatchSave() {
   batchSaving.value = true
   try {
     if (batchMode.value === 'template') {
-      await batchSetTemplate(selectedIds.value, batchTemplateId.value)
-      ElMessage.success(`已${batchTemplateId.value ? '绑定' : '解绑'}模板`)
+      await batchSetTemplate(selectedIds.value, batchTemplateIds.value)
+      ElMessage.success(batchTemplateIds.value.length ? '模板绑定已更新' : '模板已解绑')
     } else if (batchMode.value === 'notify') {
       const notifyStr = batchNotifyChannels.value.length ? JSON.stringify(batchNotifyChannels.value) : ''
       await batchSetNotify(selectedIds.value, notifyStr)

--- a/frontend/src/views/InspectionTemplates.vue
+++ b/frontend/src/views/InspectionTemplates.vue
@@ -10,6 +10,7 @@
         <h3><el-icon :size="16" :color="getCssVar('--cyan')"><List /></el-icon> 模板列表</h3>
         <div style="display: flex; gap: 8px; align-items: center;">
           <el-input v-model="keyword" placeholder="搜索模板名称" clearable style="width: 200px;" @keyup.enter="fetchData" @clear="fetchData" />
+          <el-button plain :loading="initing" @click="handleInitTemplates">初始化模板</el-button>
           <el-button type="primary" @click="openCreate"><el-icon><Plus /></el-icon> 新建模板</el-button>
         </div>
       </div>
@@ -244,7 +245,7 @@ import { ref, onMounted } from 'vue'
 import dayjs from 'dayjs'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import type { FormInstance } from 'element-plus'
-import { getTemplates, createTemplate, updateTemplate, deleteTemplate, getTemplate, getTemplateMetrics, setTemplateMetrics, getMetricTypes, saveTemplateMetricOverride } from '../api'
+import { getTemplates, createTemplate, updateTemplate, deleteTemplate, getTemplate, getTemplateMetrics, setTemplateMetrics, getMetricTypes, saveTemplateMetricOverride, initTemplates } from '../api'
 import type { MetricType } from '../types'
 
 function getCssVar(name: string): string {
@@ -253,6 +254,7 @@ function getCssVar(name: string): string {
 
 const loading = ref(false)
 const saving = ref(false)
+const initing = ref(false)
 const metricsLoading = ref(false)
 const savingMetrics = ref(false)
 const templates = ref<any[]>([])
@@ -310,6 +312,19 @@ async function handleSave() {
     await fetchData()
   } catch (e: any) { ElMessage.error(e.message) }
   finally { saving.value = false }
+}
+
+async function handleInitTemplates() {
+  initing.value = true
+  try {
+    const res = await initTemplates()
+    ElMessage.success(res.data.message || '模板初始化完成')
+    await fetchData()
+  } catch (e: any) {
+    ElMessage.error(e.message)
+  } finally {
+    initing.value = false
+  }
 }
 
 async function handleMore(row: any, cmd: string) {

--- a/main.go
+++ b/main.go
@@ -97,6 +97,9 @@ func main() {
 	if err := database.InitDB(dbPath); err != nil {
 		log.Fatalf("Failed to initialize database: %v", err)
 	}
+	if err := database.ImportSQLFileIfNeeded(config); err != nil {
+		log.Fatalf("Failed to import bootstrap SQL: %v", err)
+	}
 	// 从配置文件导入初始数据到数据库
 	if err := database.SeedFromConfig(config); err != nil {
 		log.Printf("Warning: failed to seed database: %v", err)
@@ -327,19 +330,15 @@ func startGlobalScheduler(config *config.Config, collector *metrics.Collector) {
 	if config.CronSchedule != "" {
 		_, err := globalScheduler.AddFunc(config.CronSchedule, func() {
 			log.Printf("[Cron] 执行定时巡检任务(配置文件)...")
-			data, err := collector.CollectMetrics()
-			if err != nil {
-				log.Printf("[Cron] 收集指标失败: %v", err)
-				return
+			var dsIDPtr *uint
+			if preferred := resolveConfigScheduleDatasourceID(); preferred != nil {
+				dsID := *preferred
+				dsIDPtr = &dsID
+				log.Printf("[Cron] 配置文件定时巡检将使用数据源 ID=%d", dsID)
+			} else {
+				log.Printf("[Cron] 未找到默认数据源，回退为全局配置巡检")
 			}
-			reportFilePath, err := report.GenerateReport(*data)
-			if err != nil {
-				log.Printf("[Cron] 生成报告失败: %v", err)
-				return
-			}
-			saveReportRecord(data, reportFilePath)
-			sendNotifications(config, reportFilePath, data)
-			log.Printf("[Cron] 定时巡检任务完成: %s", reportFilePath)
+			doSingleInspection(config, collector, database.CronJob{Name: "配置文件定时巡检"}, dsIDPtr)
 		})
 		if err != nil {
 			log.Printf("[Cron] 调度配置文件任务失败: %v", err)
@@ -355,6 +354,22 @@ func startGlobalScheduler(config *config.Config, collector *metrics.Collector) {
 
 	globalScheduler.Start()
 	log.Printf("[Cron] 定时调度器已启动")
+}
+
+func resolveConfigScheduleDatasourceID() *uint {
+	var defaultDS database.DataSource
+	if err := database.DB.Where("enabled = ? AND is_default = ?", true, true).
+		Order("id asc").
+		First(&defaultDS).Error; err == nil {
+		return &defaultDS.ID
+	}
+
+	var enabledSources []database.DataSource
+	database.DB.Where("enabled = ?", true).Order("id asc").Find(&enabledSources)
+	if len(enabledSources) == 1 {
+		return &enabledSources[0].ID
+	}
+	return nil
 }
 
 // executeInspectionWithProgress 带进度更新的巡检执行
@@ -599,6 +614,10 @@ func sendSingleNotification(ch database.NotificationChannel, reportFilePath, dat
 func sendNotificationsWithContext(ctx context.Context, config *config.Config, reportFilePath string, reportData *report.ReportData) {
 	// 计算告警汇总
 	alertSummary := notify.CalculateAlertSummary(*reportData)
+	projectName := config.ProjectName
+	if reportData != nil && strings.TrimSpace(reportData.Project) != "" {
+		projectName = strings.TrimSpace(reportData.Project)
+	}
 
 	log.Printf("告警汇总: 总指标=%d, 异常=%d, 严重=%d, 警告=%d, 正常=%d",
 		alertSummary.TotalMetrics, alertSummary.TotalAlerts, alertSummary.CriticalAlerts,
@@ -606,28 +625,28 @@ func sendNotificationsWithContext(ctx context.Context, config *config.Config, re
 
 	if config.Notifications.Dingtalk.Enabled {
 		log.Printf("发送钉钉消息")
-		if err := notify.SendDingtalkWithContext(ctx, config.Notifications.Dingtalk, reportFilePath, config.ProjectName, reportData.Datasource, alertSummary); err != nil {
+		if err := notify.SendDingtalkWithContext(ctx, config.Notifications.Dingtalk, reportFilePath, projectName, reportData.Datasource, alertSummary); err != nil {
 			log.Printf("发送钉钉消息失败: %v", err)
 		}
 	}
 
 	if config.Notifications.Email.Enabled {
 		log.Printf("发送邮件")
-		if err := notify.SendEmailWithContext(ctx, config.Notifications.Email, reportFilePath, config.ProjectName, reportData.Datasource, alertSummary); err != nil {
+		if err := notify.SendEmailWithContext(ctx, config.Notifications.Email, reportFilePath, projectName, reportData.Datasource, alertSummary); err != nil {
 			log.Printf("发送邮件失败: %v", err)
 		}
 	}
 
 	if config.Notifications.WeChatWork.Enabled {
 		log.Printf("发送企业微信消息")
-		if err := notify.SendWeChatWorkWithContext(ctx, config.Notifications.WeChatWork, reportFilePath, config.ProjectName, reportData.Datasource, alertSummary); err != nil {
+		if err := notify.SendWeChatWorkWithContext(ctx, config.Notifications.WeChatWork, reportFilePath, projectName, reportData.Datasource, alertSummary); err != nil {
 			log.Printf("发送企业微信消息失败: %v", err)
 		}
 	}
 
 	if config.Notifications.Feishu.Enabled {
 		log.Printf("发送飞书消息")
-		if err := notify.SendFeishuWithContext(ctx, config.Notifications.Feishu, reportFilePath, config.ProjectName, reportData.Datasource, alertSummary); err != nil {
+		if err := notify.SendFeishuWithContext(ctx, config.Notifications.Feishu, reportFilePath, projectName, reportData.Datasource, alertSummary); err != nil {
 			log.Printf("发送飞书消息失败: %v", err)
 		}
 	}
@@ -648,7 +667,7 @@ func sendNotificationsWithContext(ctx context.Context, config *config.Config, re
 			}
 		}
 
-		if err := notify.SendWeChatAppWithContext(ctx, appConfig, reportFilePath, config.ProjectName, reportData.Datasource, alertSummary); err != nil {
+		if err := notify.SendWeChatAppWithContext(ctx, appConfig, reportFilePath, projectName, reportData.Datasource, alertSummary); err != nil {
 			log.Printf("发送企业微信应用消息失败: %v", err)
 		}
 	}
@@ -667,7 +686,7 @@ func sendNotificationsWithContext(ctx context.Context, config *config.Config, re
 			}
 			log.Printf("[NOTIFICATION] 使用代理地址: %s", proxyURL)
 
-			if err := notify.SendWeChatWorkWithWebhook(ctx, wechatBotKey, proxyURL, reportFilePath, config.ProjectName, reportData.Datasource, alertSummary); err != nil {
+			if err := notify.SendWeChatWorkWithWebhook(ctx, wechatBotKey, proxyURL, reportFilePath, projectName, reportData.Datasource, alertSummary); err != nil {
 				log.Printf("[NOTIFICATION] 发送企业微信消息失败: %v", err)
 			} else {
 				log.Printf("[NOTIFICATION] 企业微信通知发送成功")
@@ -1174,9 +1193,15 @@ func doSingleInspection(cfg *config.Config, collector *metrics.Collector, job da
 		}
 
 		// 先检查连通性，不可用则立即终止
+		checkTime := time.Now()
 		hcCtx, hcCancel := context.WithTimeout(context.Background(), 10*time.Second)
 		if err := client.HealthCheck(hcCtx); err != nil {
 			hcCancel()
+			database.DB.Model(&database.DataSource{}).Where("id = ?", ds.ID).Updates(map[string]interface{}{
+				"connection_status":     "unknown",
+				"connection_checked_at": &checkTime,
+			})
+			invalidateDSCache()
 			log.Printf("[Cron] 数据源 %s 不可用: %v，跳过巡检", ds.Name, err)
 			database.DB.Create(&database.InspectRecord{
 				TaskID: taskID, Status: "failed", DatasourceID: &dsID,
@@ -1186,29 +1211,14 @@ func doSingleInspection(cfg *config.Config, collector *metrics.Collector, job da
 			return false
 		}
 		hcCancel()
+		database.DB.Model(&database.DataSource{}).Where("id = ?", ds.ID).Updates(map[string]interface{}{
+			"connection_status":     "online",
+			"connection_checked_at": &checkTime,
+		})
+		invalidateDSCache()
 
-		activeCfg := cfg
-		if ds.TemplateID != nil {
-			var links []database.InspectionTemplateMetric
-			database.DB.Where("template_id = ?", *ds.TemplateID).Find(&links)
-			if len(links) > 0 {
-				cfgIDs := make([]uint, len(links))
-				for i, l := range links {
-					cfgIDs[i] = l.MetricConfigID
-				}
-				var tmplConfigs []database.MetricConfig
-				database.DB.Where("id IN ?", cfgIDs).Find(&tmplConfigs)
-				for i := range tmplConfigs {
-					var override database.TemplateMetricOverride
-					if database.DB.Where("template_id = ? AND metric_config_id = ?", *ds.TemplateID, tmplConfigs[i].ID).First(&override).Error == nil {
-						override.Apply(&tmplConfigs[i])
-					}
-				}
-				if len(tmplConfigs) > 0 {
-					activeCfg = buildFilteredConfig(cfg, tmplConfigs)
-				}
-			}
-		}
+		database.NormalizeDataSourceTemplateFields(&ds)
+		activeCfg := buildRuntimeMetricConfig(cfg, &ds, nil)
 
 		database.DB.Create(&database.InspectRecord{
 			TaskID: taskID, Status: "running", DatasourceID: &dsID,
@@ -1372,17 +1382,28 @@ func saveReportRecord(data *report.ReportData, reportPath string) {
 		dsID = &dsRecord.ID
 	}
 	database.DB.Create(&database.ReportRecord{
-		Title:          fmt.Sprintf("巡检报告 - %s", time.Now().Format("2006-01-02 15:04")),
+		Title: func() string {
+			title := strings.TrimSpace(data.Project)
+			if title == "" {
+				title = "巡检报告"
+			}
+			return fmt.Sprintf("%s - %s", title, time.Now().Format("2006-01-02 15:04"))
+		}(),
 		DatasourceID:   dsID,
 		DatasourceName: data.Datasource,
 		FilePath:       reportPath,
-		FileSize:       func() int64 { if info != nil { return info.Size() }; return 0 }(),
-		TotalMetrics:   totalMetrics,
-		AlertCount:     alertCount,
-		CriticalCount:  criticalCount,
-		WarningCount:   warningCount,
-		Status:         status,
-		MetricsJSON:    buildHealthSnapshot(data),
+		FileSize: func() int64 {
+			if info != nil {
+				return info.Size()
+			}
+			return 0
+		}(),
+		TotalMetrics:  totalMetrics,
+		AlertCount:    alertCount,
+		CriticalCount: criticalCount,
+		WarningCount:  warningCount,
+		Status:        status,
+		MetricsJSON:   buildHealthSnapshot(data),
 	})
 }
 

--- a/pkg/database/db.go
+++ b/pkg/database/db.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 	"time"
 
 	"PromAI/pkg/config"
@@ -37,149 +38,362 @@ func InitDB(dbPath string) error {
 	if err := AutoMigrate(DB); err != nil {
 		return fmt.Errorf("failed to auto migrate: %w", err)
 	}
+	if err := migrateTemplateIDs(DB); err != nil {
+		return fmt.Errorf("failed to migrate template ids: %w", err)
+	}
 
 	log.Printf("数据库初始化成功: %s", dbPath)
 	return nil
 }
 
 func SeedFromConfig(cfg *config.Config) error {
-	var count int64
-	DB.Model(&DataSource{}).Count(&count)
-	if count > 0 {
-		log.Printf("数据库已有数据，跳过初始化导入")
+	if cfg == nil {
 		return nil
 	}
 
-	log.Printf("首次运行，从配置文件导入数据到数据库...")
-
-	defaultDS := DataSource{
-		Name:      "默认数据源",
-		URL:       cfg.PrometheusURL,
-		Username:  cfg.PrometheusUsername,
-		Password:  cfg.PrometheusPassword,
-		IsDefault: true,
+	if err := ensureDefaultDatasource(cfg); err != nil {
+		return err
 	}
-	DB.Create(&defaultDS)
-
-	for _, ds := range cfg.DataSources {
-		d := DataSource{
-			Name:     ds.Name,
-			URL:      ds.URL,
-			Username: ds.UserName,
-			Password: ds.Password,
-		}
-		DB.Create(&d)
+	if err := ensureConfiguredDatasources(cfg); err != nil {
+		return err
+	}
+	if err := ensureMetricCatalog(cfg); err != nil {
+		return err
+	}
+	if err := ensureNotificationChannels(cfg); err != nil {
+		return err
+	}
+	if err := ensureAppSettings(cfg); err != nil {
+		return err
+	}
+	if err := InitializeTemplatesFromMetricTypes(); err != nil {
+		return err
 	}
 
-	for _, mt := range cfg.MetricTypes {
-		mType := MetricType{
-			TypeName:  mt.Type,
-			SortOrder: 0,
-		}
-		DB.Create(&mType)
+	log.Printf("配置数据已同步到数据库")
+	return nil
+}
 
-		for _, m := range mt.Metrics {
-			labelsBytes, _ := json.Marshal(m.Labels)
-			mc := MetricConfig{
-				MetricTypeID:    mType.ID,
-				Name:            m.Name,
-				Description:     m.Description,
-				Query:           m.Query,
-				Threshold:       m.Threshold,
-				ThresholdType:   m.ThresholdType,
-				ThresholdStatus: m.ThresholdStatus,
-				Unit:            m.Unit,
-				LabelsJSON:      string(labelsBytes),
-			}
-			DB.Create(&mc)
-		}
+func ImportSQLFileIfNeeded(cfg *config.Config) error {
+	if strings.ToLower(strings.TrimSpace(os.Getenv("PROMAI_IMPORT_SQL_ON_START"))) != "true" {
+		return nil
+	}
+	if cfg != nil && len(cfg.MetricTypes) > 0 {
+		log.Printf("config.yaml 已配置 metric_types，跳过 SQL 初始化")
+		return nil
 	}
 
-	DB.Create(&NotificationChannel{
-		ChannelType: "dingtalk",
-		Name:        "钉钉通知",
-		Enabled:     cfg.Notifications.Dingtalk.Enabled,
-		ConfigJSON:  marshalJSON(cfg.Notifications.Dingtalk),
-	})
-	DB.Create(&NotificationChannel{
-		ChannelType: "email",
-		Name:        "邮件通知",
-		Enabled:     cfg.Notifications.Email.Enabled,
-		ConfigJSON:  marshalJSON(cfg.Notifications.Email),
-	})
-	DB.Create(&NotificationChannel{
-		ChannelType: "wechat_work",
-		Name:        "企业微信机器人",
-		Enabled:     cfg.Notifications.WeChatWork.Enabled,
-		ConfigJSON:  marshalJSON(cfg.Notifications.WeChatWork),
-	})
-	DB.Create(&NotificationChannel{
-		ChannelType: "wechat_app",
-		Name:        "企业微信应用",
-		Enabled:     cfg.Notifications.WeChatApp.Enabled,
-		ConfigJSON:  marshalJSON(cfg.Notifications.WeChatApp),
-	})
-	DB.Create(&NotificationChannel{
-		ChannelType: "feishu",
-		Name:        "飞书通知",
-		Enabled:     cfg.Notifications.Feishu.Enabled,
-		ConfigJSON:  marshalJSON(cfg.Notifications.Feishu),
-	})
+	sqlFile := strings.TrimSpace(os.Getenv("PROMAI_IMPORT_SQL_FILE"))
+	if sqlFile == "" {
+		return nil
+	}
 
-	DB.Create(&AppSetting{Key: "project_name", Value: cfg.ProjectName})
-	DB.Create(&AppSetting{Key: "cron_schedule", Value: cfg.CronSchedule})
+	content, err := os.ReadFile(sqlFile)
+	if err != nil {
+		return fmt.Errorf("reading import sql file %s: %w", sqlFile, err)
+	}
+	sqlText := strings.TrimSpace(string(content))
+	if sqlText == "" {
+		log.Printf("SQL 初始化文件为空，跳过: %s", sqlFile)
+		return nil
+	}
+	if !strings.Contains(strings.ToUpper(sqlText), "INSERT ") {
+		log.Printf("SQL 初始化文件未包含 INSERT 语句，跳过: %s", sqlFile)
+		return nil
+	}
 
-	DB.Create(&AppSetting{Key: "report_cleanup_enabled", Value: fmt.Sprintf("%v", cfg.ReportCleanup.Enabled)})
-	DB.Create(&AppSetting{Key: "report_cleanup_max_age", Value: fmt.Sprintf("%d", cfg.ReportCleanup.MaxAge)})
-	DB.Create(&AppSetting{Key: "report_cleanup_cron", Value: cfg.ReportCleanup.CronSchedule})
+	if err := DB.Exec(sqlText).Error; err != nil {
+		return fmt.Errorf("executing import sql file %s: %w", sqlFile, err)
+	}
+	log.Printf("SQL 初始化完成: %s", sqlFile)
+	return nil
+}
 
-	for _, mt := range cfg.MetricTypes {
-		typeName := mt.Type
-		// Find the MetricType we just created
-		var mType MetricType
-		if err := DB.Where("type_name = ?", typeName).First(&mType).Error; err != nil {
+func ensureDefaultDatasource(cfg *config.Config) error {
+	if cfg.PrometheusURL == "" {
+		return nil
+	}
+	var ds DataSource
+	err := DB.Where("is_default = ? OR url = ?", true, cfg.PrometheusURL).First(&ds).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return DB.Create(&DataSource{
+				Name:      "默认数据源",
+				URL:       cfg.PrometheusURL,
+				Username:  cfg.PrometheusUsername,
+				Password:  cfg.PrometheusPassword,
+				IsDefault: true,
+				Enabled:   true,
+			}).Error
+		}
+		return err
+	}
+	updates := map[string]any{
+		"name":       firstNonEmpty(ds.Name, "默认数据源"),
+		"url":        cfg.PrometheusURL,
+		"username":   cfg.PrometheusUsername,
+		"password":   cfg.PrometheusPassword,
+		"is_default": true,
+	}
+	return DB.Model(&ds).Updates(updates).Error
+}
+
+func ensureConfiguredDatasources(cfg *config.Config) error {
+	for _, item := range cfg.DataSources {
+		if item.Name == "" || item.URL == "" {
 			continue
 		}
-		tmpl := InspectionTemplate{
-			Name:        typeName,
-			Description: fmt.Sprintf("基于「%s」自动创建的默认模板", typeName),
+		var ds DataSource
+		err := DB.Where("name = ? OR url = ?", item.Name, item.URL).First(&ds).Error
+		if err != nil {
+			if err == gorm.ErrRecordNotFound {
+				if err := DB.Create(&DataSource{
+					Name:     item.Name,
+					URL:      item.URL,
+					Username: item.UserName,
+					Password: item.Password,
+					Enabled:  true,
+				}).Error; err != nil {
+					return err
+				}
+				continue
+			}
+			return err
 		}
-		DB.Create(&tmpl)
-		// Associate all metrics in this group with the template
-		var configs []MetricConfig
-		DB.Where("metric_type_id = ?", mType.ID).Find(&configs)
-		for _, mc := range configs {
-			DB.Create(&InspectionTemplateMetric{
-				TemplateID:     tmpl.ID,
-				MetricConfigID: mc.ID,
-			})
-		}
-	}
-
-	// 创建全局模板（包含全部指标）
-	var allConfigs []MetricConfig
-	DB.Where("metric_type_id IS NOT NULL").Find(&allConfigs)
-	if len(allConfigs) > 0 {
-		globalTmpl := InspectionTemplate{
-			Name:        "全局模板",
-			Description: "包含全部全局指标的默认模板",
-		}
-		DB.Create(&globalTmpl)
-		for _, mc := range allConfigs {
-			DB.Create(&InspectionTemplateMetric{
-				TemplateID:     globalTmpl.ID,
-				MetricConfigID: mc.ID,
-			})
+		if err := DB.Model(&ds).Updates(map[string]any{
+			"name":     item.Name,
+			"url":      item.URL,
+			"username": item.UserName,
+			"password": item.Password,
+		}).Error; err != nil {
+			return err
 		}
 	}
-
-	log.Printf("数据导入完成")
 	return nil
+}
+
+func ensureMetricCatalog(cfg *config.Config) error {
+	for i, mt := range cfg.MetricTypes {
+		if mt.Type == "" {
+			continue
+		}
+		var mType MetricType
+		err := DB.Where("type_name = ?", mt.Type).First(&mType).Error
+		if err != nil {
+			if err == gorm.ErrRecordNotFound {
+				mType = MetricType{TypeName: mt.Type, SortOrder: i}
+				if err := DB.Create(&mType).Error; err != nil {
+					return err
+				}
+			} else {
+				return err
+			}
+		} else if mType.SortOrder != i {
+			if err := DB.Model(&mType).Update("sort_order", i).Error; err != nil {
+				return err
+			}
+		}
+
+		for j, metric := range mt.Metrics {
+			var existing MetricConfig
+			err := DB.Where("metric_type_id = ? AND datasource_id IS NULL AND name = ?", mType.ID, metric.Name).First(&existing).Error
+			payload := MetricConfig{
+				MetricTypeID:    mType.ID,
+				Name:            metric.Name,
+				Description:     metric.Description,
+				Query:           metric.Query,
+				Threshold:       metric.Threshold,
+				ThresholdType:   defaultThresholdType(metric.ThresholdType),
+				ThresholdStatus: defaultThresholdStatus(metric.ThresholdStatus),
+				Unit:            metric.Unit,
+				LabelsJSON:      marshalJSON(metric.Labels),
+				SortOrder:       j,
+			}
+			if err != nil {
+				if err == gorm.ErrRecordNotFound {
+					if err := DB.Create(&payload).Error; err != nil {
+						return err
+					}
+				} else {
+					return err
+				}
+				continue
+			}
+			if err := DB.Model(&existing).Updates(map[string]any{
+				"description":      payload.Description,
+				"query":            payload.Query,
+				"threshold":        payload.Threshold,
+				"threshold_type":   payload.ThresholdType,
+				"threshold_status": payload.ThresholdStatus,
+				"unit":             payload.Unit,
+				"labels_json":      payload.LabelsJSON,
+				"sort_order":       payload.SortOrder,
+			}).Error; err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func ensureNotificationChannels(cfg *config.Config) error {
+	channels := []NotificationChannel{
+		{ChannelType: "dingtalk", Name: "钉钉通知", Enabled: cfg.Notifications.Dingtalk.Enabled, ConfigJSON: marshalJSON(cfg.Notifications.Dingtalk)},
+		{ChannelType: "email", Name: "邮件通知", Enabled: cfg.Notifications.Email.Enabled, ConfigJSON: marshalJSON(cfg.Notifications.Email)},
+		{ChannelType: "wechat_work", Name: "企业微信机器人", Enabled: cfg.Notifications.WeChatWork.Enabled, ConfigJSON: marshalJSON(cfg.Notifications.WeChatWork)},
+		{ChannelType: "wechat_app", Name: "企业微信应用", Enabled: cfg.Notifications.WeChatApp.Enabled, ConfigJSON: marshalJSON(cfg.Notifications.WeChatApp)},
+		{ChannelType: "feishu", Name: "飞书通知", Enabled: cfg.Notifications.Feishu.Enabled, ConfigJSON: marshalJSON(cfg.Notifications.Feishu)},
+	}
+	for _, ch := range channels {
+		var existing NotificationChannel
+		err := DB.Where("channel_type = ?", ch.ChannelType).First(&existing).Error
+		if err != nil {
+			if err == gorm.ErrRecordNotFound {
+				if err := DB.Create(&ch).Error; err != nil {
+					return err
+				}
+			} else {
+				return err
+			}
+			continue
+		}
+		if err := DB.Model(&existing).Updates(map[string]any{
+			"name": ch.Name,
+		}).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func ensureAppSettings(cfg *config.Config) error {
+	settings := map[string]string{
+		"project_name":           cfg.ProjectName,
+		"cron_schedule":          cfg.CronSchedule,
+		"report_cleanup_enabled": fmt.Sprintf("%v", cfg.ReportCleanup.Enabled),
+		"report_cleanup_max_age": fmt.Sprintf("%d", cfg.ReportCleanup.MaxAge),
+		"report_cleanup_cron":    cfg.ReportCleanup.CronSchedule,
+	}
+	for key, value := range settings {
+		if err := upsertAppSetting(key, value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func InitializeTemplatesFromMetricTypes() error {
+	var metricTypes []MetricType
+	if err := DB.Order("sort_order asc, id asc").Find(&metricTypes).Error; err != nil {
+		return err
+	}
+	for _, mt := range metricTypes {
+		if mt.TypeName == "" {
+			continue
+		}
+		var tmpl InspectionTemplate
+		err := DB.Where("name = ?", mt.TypeName).First(&tmpl).Error
+		desc := fmt.Sprintf("基于「%s」自动创建的默认模板", mt.TypeName)
+		if err != nil {
+			if err == gorm.ErrRecordNotFound {
+				tmpl = InspectionTemplate{Name: mt.TypeName, Description: desc}
+				if err := DB.Create(&tmpl).Error; err != nil {
+					return err
+				}
+			} else {
+				return err
+			}
+		} else if tmpl.Description == "" {
+			if err := DB.Model(&tmpl).Update("description", desc).Error; err != nil {
+				return err
+			}
+		}
+
+		var configs []MetricConfig
+		if err := DB.Where("metric_type_id = ?", mt.ID).Order("sort_order asc, id asc").Find(&configs).Error; err != nil {
+			return err
+		}
+		if err := ensureTemplateLinks(tmpl.ID, configs); err != nil {
+			return err
+		}
+	}
+
+	var global InspectionTemplate
+	if err := DB.Where("name = ?", "全局模板").First(&global).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			global = InspectionTemplate{Name: "全局模板", Description: "包含全部全局指标的默认模板"}
+			if err := DB.Create(&global).Error; err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+	var allConfigs []MetricConfig
+	if err := DB.Where("metric_type_id IS NOT NULL").Order("metric_type_id asc, sort_order asc, id asc").Find(&allConfigs).Error; err != nil {
+		return err
+	}
+	return ensureTemplateLinks(global.ID, allConfigs)
+}
+
+func ensureTemplateLinks(templateID uint, configs []MetricConfig) error {
+	for _, cfg := range configs {
+		var link InspectionTemplateMetric
+		err := DB.Where("template_id = ? AND metric_config_id = ?", templateID, cfg.ID).First(&link).Error
+		if err == nil {
+			continue
+		}
+		if err != gorm.ErrRecordNotFound {
+			return err
+		}
+		if err := DB.Create(&InspectionTemplateMetric{
+			TemplateID:     templateID,
+			MetricConfigID: cfg.ID,
+		}).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func upsertAppSetting(key, value string) error {
+	var setting AppSetting
+	err := DB.Where("key = ?", key).First(&setting).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return DB.Create(&AppSetting{Key: key, Value: value}).Error
+		}
+		return err
+	}
+	return DB.Model(&setting).Update("value", value).Error
 }
 
 func marshalJSON(v interface{}) string {
 	b, _ := json.Marshal(v)
 	return string(b)
+}
+
+func defaultThresholdType(v string) string {
+	if v == "" {
+		return "greater"
+	}
+	return v
+}
+
+func defaultThresholdStatus(v string) string {
+	if v == "" {
+		return "critical"
+	}
+	return v
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 func LoadConfigFile(path string) (*config.Config, error) {

--- a/pkg/database/models.go
+++ b/pkg/database/models.go
@@ -7,18 +7,25 @@ import (
 )
 
 type DataSource struct {
-	ID             uint      `gorm:"primaryKey" json:"id"`
-	Name           string    `gorm:"uniqueIndex;size:100;not null" json:"name"`
-	URL            string    `gorm:"size:500;not null" json:"url"`
-	Username       string    `gorm:"size:100" json:"username"`
-	Password       string    `gorm:"size:100" json:"password"`
-	IsDefault      bool      `gorm:"default:false" json:"is_default"`
-	Enabled        bool      `gorm:"default:true" json:"enabled"`
-	TemplateID     *uint     `json:"template_id"`
-	NotifyChannels string    `gorm:"type:text" json:"notify_channels"`
-	CreatedAt      time.Time `json:"created_at"`
-	UpdatedAt      time.Time `json:"updated_at"`
-	HealthStatus   string    `gorm:"-" json:"health_status"`
+	ID                  uint       `gorm:"primaryKey" json:"id"`
+	Name                string     `gorm:"uniqueIndex;size:100;not null" json:"name"`
+	URL                 string     `gorm:"size:500;not null" json:"url"`
+	Username            string     `gorm:"size:100" json:"username"`
+	Password            string     `gorm:"size:100" json:"password"`
+	IsDefault           bool       `gorm:"default:false" json:"is_default"`
+	Enabled             bool       `gorm:"default:true" json:"enabled"`
+	TemplateID          *uint      `json:"template_id"`
+	TemplateIDsRaw      string     `gorm:"column:template_ids;type:text" json:"-"`
+	TemplateIDs         []uint     `gorm:"-" json:"template_ids,omitempty"`
+	ProjectName         string     `gorm:"size:200" json:"project_name"`
+	ConnectionStatus    string     `gorm:"size:50" json:"connection_status"`
+	ConnectionCheckedAt *time.Time `json:"connection_checked_at,omitempty"`
+	NotifyChannels      string     `gorm:"type:text" json:"notify_channels"`
+	CreatedAt           time.Time  `json:"created_at"`
+	UpdatedAt           time.Time  `json:"updated_at"`
+	HealthStatus        string     `gorm:"-" json:"health_status"`
+	ReportStatus        string     `gorm:"-" json:"report_status,omitempty"`
+	LastReportAt        *time.Time `gorm:"-" json:"last_report_at,omitempty"`
 }
 
 type MetricType struct {
@@ -31,18 +38,18 @@ type MetricType struct {
 }
 
 type MetricConfig struct {
-	ID              uint   `gorm:"primaryKey" json:"id"`
-	MetricTypeID    uint   `gorm:"not null;index" json:"metric_type_id"`
-	DatasourceID    *uint  `gorm:"index" json:"datasource_id"`
-	Name            string `gorm:"size:200;not null" json:"name"`
-	Description     string `gorm:"size:500" json:"description"`
-	Query           string `gorm:"type:text;not null" json:"query"`
-	Threshold       float64 `json:"threshold"`
-	ThresholdType   string `gorm:"size:50;default:greater" json:"threshold_type"`
-	ThresholdStatus string `gorm:"size:50;default:critical" json:"threshold_status"`
-	Unit            string `gorm:"size:50" json:"unit"`
-	LabelsJSON      string `gorm:"type:text" json:"labels_json"`
-	SortOrder       int    `gorm:"default:0" json:"sort_order"`
+	ID              uint      `gorm:"primaryKey" json:"id"`
+	MetricTypeID    uint      `gorm:"not null;index" json:"metric_type_id"`
+	DatasourceID    *uint     `gorm:"index" json:"datasource_id"`
+	Name            string    `gorm:"size:200;not null" json:"name"`
+	Description     string    `gorm:"size:500" json:"description"`
+	Query           string    `gorm:"type:text;not null" json:"query"`
+	Threshold       float64   `json:"threshold"`
+	ThresholdType   string    `gorm:"size:50;default:greater" json:"threshold_type"`
+	ThresholdStatus string    `gorm:"size:50;default:critical" json:"threshold_status"`
+	Unit            string    `gorm:"size:50" json:"unit"`
+	LabelsJSON      string    `gorm:"type:text" json:"labels_json"`
+	SortOrder       int       `gorm:"default:0" json:"sort_order"`
 	CreatedAt       time.Time `json:"created_at"`
 	UpdatedAt       time.Time `json:"updated_at"`
 }
@@ -58,35 +65,35 @@ type NotificationChannel struct {
 }
 
 type CronJob struct {
-	ID              uint       `gorm:"primaryKey" json:"id"`
-	Name            string     `gorm:"size:200;not null" json:"name"`
-	Schedule        string     `gorm:"size:100;not null" json:"schedule"`
-	DatasourceID    *uint      `json:"datasource_id"`               // 旧版单数据源（向后兼容）
-	DatasourceIDs   string     `gorm:"type:text" json:"datasource_ids"`     // 多数据源 JSON 数组
-	AllDatasources  bool       `json:"all_datasources"`                      // 全部数据源
-	Enabled         bool       `gorm:"default:true" json:"enabled"`
-	NotifyChannels  string     `gorm:"type:text" json:"notify_channels"`
-	LastRunAt       *time.Time `json:"last_run_at"`
-	LastStatus      string     `gorm:"size:50" json:"last_status"`
-	CreatedAt       time.Time  `json:"created_at"`
-	UpdatedAt       time.Time  `json:"updated_at"`
+	ID             uint       `gorm:"primaryKey" json:"id"`
+	Name           string     `gorm:"size:200;not null" json:"name"`
+	Schedule       string     `gorm:"size:100;not null" json:"schedule"`
+	DatasourceID   *uint      `json:"datasource_id"`                   // 旧版单数据源（向后兼容）
+	DatasourceIDs  string     `gorm:"type:text" json:"datasource_ids"` // 多数据源 JSON 数组
+	AllDatasources bool       `json:"all_datasources"`                 // 全部数据源
+	Enabled        bool       `gorm:"default:true" json:"enabled"`
+	NotifyChannels string     `gorm:"type:text" json:"notify_channels"`
+	LastRunAt      *time.Time `json:"last_run_at"`
+	LastStatus     string     `gorm:"size:50" json:"last_status"`
+	CreatedAt      time.Time  `json:"created_at"`
+	UpdatedAt      time.Time  `json:"updated_at"`
 }
 
 type ReportRecord struct {
-	ID              uint      `gorm:"primaryKey" json:"id"`
-	Title           string    `gorm:"size:200" json:"title"`
-	DatasourceID    *uint     `json:"datasource_id"`
-	DatasourceName  string    `gorm:"size:200" json:"datasource_name"`
-	FilePath        string    `gorm:"size:500" json:"file_path"`
-	FileSize        int64     `json:"file_size"`
-	TotalMetrics    int       `json:"total_metrics"`
-	AlertCount      int       `json:"alert_count"`
-	CriticalCount   int       `json:"critical_count"`
-	WarningCount    int       `json:"warning_count"`
-	Status          string    `gorm:"size:50" json:"status"`
-	Duration        string    `gorm:"size:50" json:"duration"`
-	MetricsJSON     string    `gorm:"type:text" json:"metrics_json"`
-	CreatedAt       time.Time `json:"created_at"`
+	ID             uint      `gorm:"primaryKey" json:"id"`
+	Title          string    `gorm:"size:200" json:"title"`
+	DatasourceID   *uint     `json:"datasource_id"`
+	DatasourceName string    `gorm:"size:200" json:"datasource_name"`
+	FilePath       string    `gorm:"size:500" json:"file_path"`
+	FileSize       int64     `json:"file_size"`
+	TotalMetrics   int       `json:"total_metrics"`
+	AlertCount     int       `json:"alert_count"`
+	CriticalCount  int       `json:"critical_count"`
+	WarningCount   int       `json:"warning_count"`
+	Status         string    `gorm:"size:50" json:"status"`
+	Duration       string    `gorm:"size:50" json:"duration"`
+	MetricsJSON    string    `gorm:"type:text" json:"metrics_json"`
+	CreatedAt      time.Time `json:"created_at"`
 }
 
 type AppSetting struct {
@@ -155,16 +162,16 @@ type SyncSource struct {
 	Name          string    `gorm:"size:200;not null" json:"name"`
 	URL           string    `gorm:"size:500;not null" json:"url"`
 	Method        string    `gorm:"size:10;default:GET" json:"method"`
-	Headers       string    `gorm:"type:text" json:"headers"`      // JSON object
-	Body          string    `gorm:"type:text" json:"body"`         // request body template
+	Headers       string    `gorm:"type:text" json:"headers"`              // JSON object
+	Body          string    `gorm:"type:text" json:"body"`                 // request body template
 	AuthType      string    `gorm:"size:20;default:none" json:"auth_type"` // none, basic, bearer
 	AuthUsername  string    `gorm:"size:100" json:"auth_username"`
 	AuthPassword  string    `gorm:"size:100" json:"auth_password"`
 	AuthToken     string    `gorm:"size:500" json:"auth_token"`
-	DataPath      string    `gorm:"size:200" json:"data_path"`     // JSON path to data array (e.g. "data.items")
+	DataPath      string    `gorm:"size:200" json:"data_path"` // JSON path to data array (e.g. "data.items")
 	NameField     string    `gorm:"size:100;not null" json:"name_field"`
 	URLField      string    `gorm:"size:100" json:"url_field"`
-	URLTemplate   string    `gorm:"size:500" json:"url_template"`  // e.g. http://{host}:{port}
+	URLTemplate   string    `gorm:"size:500" json:"url_template"` // e.g. http://{host}:{port}
 	UsernameField string    `gorm:"size:100" json:"username_field"`
 	PasswordField string    `gorm:"size:100" json:"password_field"`
 	CronExpr      string    `gorm:"size:50" json:"cron_expr"`

--- a/pkg/database/template_ids.go
+++ b/pkg/database/template_ids.go
@@ -1,0 +1,131 @@
+package database
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+
+	"gorm.io/gorm"
+)
+
+func ParseTemplateIDs(raw string) []uint {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+
+	var ids []uint
+	if strings.HasPrefix(raw, "[") {
+		var arr []uint
+		if json.Unmarshal([]byte(raw), &arr) == nil {
+			return uniqueTemplateIDs(arr)
+		}
+	}
+
+	parts := strings.Split(raw, ",")
+	for _, part := range parts {
+		part = strings.TrimSpace(strings.Trim(part, "[]"))
+		if part == "" {
+			continue
+		}
+		id, err := strconv.ParseUint(part, 10, 64)
+		if err != nil || id == 0 {
+			continue
+		}
+		ids = append(ids, uint(id))
+	}
+	return uniqueTemplateIDs(ids)
+}
+
+func EncodeTemplateIDs(ids []uint) string {
+	ids = uniqueTemplateIDs(ids)
+	if len(ids) == 0 {
+		return ""
+	}
+	b, err := json.Marshal(ids)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+func PrimaryTemplateID(ids []uint) *uint {
+	if len(ids) == 0 || ids[0] == 0 {
+		return nil
+	}
+	id := ids[0]
+	return &id
+}
+
+func NormalizeDataSourceTemplateFields(ds *DataSource) {
+	if ds == nil {
+		return
+	}
+	ids := uniqueTemplateIDs(ds.TemplateIDs)
+	if len(ids) == 0 {
+		ids = ParseTemplateIDs(ds.TemplateIDsRaw)
+	}
+	if len(ids) == 0 && ds.TemplateID != nil && *ds.TemplateID > 0 {
+		ids = []uint{*ds.TemplateID}
+	}
+	ds.TemplateIDs = ids
+	ds.TemplateIDsRaw = EncodeTemplateIDs(ids)
+	ds.TemplateID = PrimaryTemplateID(ids)
+}
+
+func NormalizeDataSourcesTemplateFields(list []DataSource) {
+	for i := range list {
+		NormalizeDataSourceTemplateFields(&list[i])
+	}
+}
+
+func migrateTemplateIDs(db *gorm.DB) error {
+	var sources []DataSource
+	if err := db.Find(&sources).Error; err != nil {
+		return err
+	}
+	for i := range sources {
+		beforeRaw := sources[i].TemplateIDsRaw
+		beforePrimary := sources[i].TemplateID
+		NormalizeDataSourceTemplateFields(&sources[i])
+		if beforeRaw == sources[i].TemplateIDsRaw && samePrimaryTemplateID(beforePrimary, sources[i].TemplateID) {
+			continue
+		}
+		if err := db.Model(&DataSource{}).Where("id = ?", sources[i].ID).Updates(map[string]any{
+			"template_id":  sources[i].TemplateID,
+			"template_ids": sources[i].TemplateIDsRaw,
+		}).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func uniqueTemplateIDs(ids []uint) []uint {
+	if len(ids) == 0 {
+		return nil
+	}
+	seen := make(map[uint]struct{}, len(ids))
+	result := make([]uint, 0, len(ids))
+	for _, id := range ids {
+		if id == 0 {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		result = append(result, id)
+	}
+	return result
+}
+
+func samePrimaryTemplateID(a, b *uint) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}

--- a/pkg/notify/notify.go
+++ b/pkg/notify/notify.go
@@ -12,9 +12,9 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"os"
 	"net/smtp"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -197,16 +197,16 @@ func SendFeishuWithContext(ctx context.Context, config FeishuConfig, reportPath 
 	typeSummaryText := ""
 	if len(typeSummaries) > 0 {
 		for _, s := range typeSummaries {
-		status := "✅"
-		if s.TotalMetrics == 0 {
-			status = "⚪"
-		} else if s.CriticalCount > 0 {
-			status = "❌"
-		} else if s.WarningCount > 0 {
-			status = "⚠️"
-		}
-		typeSummaryText += fmt.Sprintf("%s%s：总%d个，异常%d个（严重%d，警告%d），正常%d个\n",
-			status, s.Type, s.TotalMetrics, s.CriticalCount+s.WarningCount, s.CriticalCount, s.WarningCount, s.NormalCount)
+			status := "✅"
+			if s.TotalMetrics == 0 {
+				status = "⚪"
+			} else if s.CriticalCount > 0 {
+				status = "❌"
+			} else if s.WarningCount > 0 {
+				status = "⚠️"
+			}
+			typeSummaryText += fmt.Sprintf("%s%s：总%d个，异常%d个（严重%d，警告%d），正常%d个\n",
+				status, s.Type, s.TotalMetrics, s.CriticalCount+s.WarningCount, s.CriticalCount, s.WarningCount, s.NormalCount)
 		}
 	} else {
 		typeSummaryText = "暂无分类数据\n"
@@ -321,11 +321,17 @@ func SendDingtalkWithContext(ctx context.Context, config DingtalkConfig, reportP
 		return nil
 	}
 	log.Printf("开始发送钉钉通知...")
+	if strings.TrimSpace(config.Webhook) == "" {
+		return fmt.Errorf("钉钉 webhook 未配置")
+	}
 
 	// 计算时间戳和签名
-	timestamp := time.Now().UnixMilli()
-	sign := calculateDingtalkSign(timestamp, config.Secret)
-	webhook := fmt.Sprintf("%s&timestamp=%d&sign=%s", config.Webhook, timestamp, sign)
+	webhook := config.Webhook
+	if strings.TrimSpace(config.Secret) != "" {
+		timestamp := time.Now().UnixMilli()
+		sign := calculateDingtalkSign(timestamp, config.Secret)
+		webhook = fmt.Sprintf("%s&timestamp=%d&sign=%s", config.Webhook, timestamp, sign)
+	}
 
 	log.Printf("准备发送请求到 webhook: %s", webhook)
 
@@ -339,8 +345,8 @@ func SendDingtalkWithContext(ctx context.Context, config DingtalkConfig, reportP
 		typeSummaries = []TypeAlertSummary{}
 	}
 
-	// 构建分类巡检结果文本（用钉钉支持的<br/>换行，每个条目单独一行）
-	typeSummaryText := ""
+	// 构建分类巡检结果文本
+	typeSummaryLines := make([]string, 0, len(typeSummaries))
 	if len(typeSummaries) > 0 {
 		for _, summary := range typeSummaries {
 			var typeStatus string
@@ -353,14 +359,14 @@ func SendDingtalkWithContext(ctx context.Context, config DingtalkConfig, reportP
 			} else {
 				typeStatus = "✅" // 正常
 			}
-			// 关键：用<br/>替代\n，适配钉钉Markdown换行
-			typeSummaryText += fmt.Sprintf("%s%s：总%d个，异常%d个（严重%d，警告%d），正常%d个<br/>",
+			typeSummaryLines = append(typeSummaryLines, fmt.Sprintf("- %s%s：总%d个，异常%d个（严重%d，警告%d），正常%d个",
 				typeStatus, summary.Type, summary.TotalMetrics,
-				summary.CriticalCount+summary.WarningCount, summary.CriticalCount, summary.WarningCount, summary.NormalCount)
+				summary.CriticalCount+summary.WarningCount, summary.CriticalCount, summary.WarningCount, summary.NormalCount))
 		}
 	} else {
-		typeSummaryText = "暂无分类数据<br/>"
+		typeSummaryLines = append(typeSummaryLines, "- 暂无分类数据")
 	}
+	typeSummaryText := strings.Join(typeSummaryLines, "\n\n")
 
 	// 生成报告的访问链接
 	reportFileName := filepath.Base(reportPath)
@@ -369,7 +375,7 @@ func SendDingtalkWithContext(ctx context.Context, config DingtalkConfig, reportP
 		reportLink = utils.GetReportURL(r, reportFileName)
 		log.Printf("使用动态URL生成报告链接: %s", reportLink)
 	} else {
-		reportLink = fmt.Sprintf("%s/api/promai/reports/%s", config.ReportURL, reportFileName)
+		reportLink = utils.BuildReportURL(config.ReportURL, reportFileName)
 		log.Printf("使用配置的静态URL生成报告链接: %s", reportLink)
 	}
 
@@ -379,29 +385,28 @@ func SendDingtalkWithContext(ctx context.Context, config DingtalkConfig, reportP
 		alertStatus = "⚠️ 异常"
 	}
 
-	// 构建钉钉专属Markdown模板（移除>缩进，用<br/>换行）
+	// 使用 actionCard 提供稳定的跳转按钮，避免 markdown 链接在钉钉内不可点击
 	messageContent := map[string]interface{}{
-		"msgtype": "markdown",
-		"markdown": map[string]string{
+		"msgtype": "actionCard",
+		"actionCard": map[string]string{
 			"title": "巡检报告",
 			"text": fmt.Sprintf("## 🔍 巡检报告 %s\n\n"+
-				"### ⌚ 巡检时间\n"+
+				"### ⌚ 巡检时间\n\n"+
 				"%s\n\n"+
-				"### 📊 分类巡检结果\n"+
+				"### 📊 分类巡检结果\n\n"+
 				"%s\n\n"+
-				"### 📈 整体统计\n"+
-				"**总指标数**：%d个<br/>"+
-				"**异常指标**：%d个（严重%d个，警告%d个）<br/>"+
-				"**正常指标**：%d个\n\n"+
-				"### 📋 点击查看完整报告\n"+
-				"**文件名**：`%s`<br/>"+
-				"**访问链接**：[点击查看报告](%s)\n\n"+
-				"---\n"+
-				"💡 请登录环境查看完整报告内容<br/>"+
+				"### 📈 整体统计\n\n"+
+				"- 总指标数：%d个\n"+
+				"- 异常指标：%d个（严重%d个，警告%d个）\n"+
+				"- 正常指标：%d个\n\n"+
+				"### 📋 报告信息\n\n"+
+				"- 文件名：`%s`\n"+
+				"- 报告地址：%s\n\n"+
+				"💡 如果按钮无法打开，请复制上面的报告地址到浏览器访问\n\n"+
 				"⏰ 生成时间：%s",
 				alertStatus,
 				time.Now().Format("2006-01-02 15:04:05"),
-				typeSummaryText, // 带<br/>的分类文本
+				typeSummaryText,
 				alertSummary.TotalMetrics,
 				alertSummary.TotalAlerts,
 				alertSummary.CriticalAlerts,
@@ -410,6 +415,9 @@ func SendDingtalkWithContext(ctx context.Context, config DingtalkConfig, reportP
 				reportFileName,
 				reportLink,
 				time.Now().Format("2006-01-02 15:04:05")),
+			"singleTitle":    "查看完整报告",
+			"singleURL":      reportLink,
+			"btnOrientation": "0",
 		},
 	}
 
@@ -437,11 +445,53 @@ func SendDingtalkWithContext(ctx context.Context, config DingtalkConfig, reportP
 	respBody, _ := io.ReadAll(resp.Body)
 	log.Printf("钉钉响应状态码: %d, 响应内容: %s", resp.StatusCode, string(respBody))
 
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("钉钉发送失败，状态码: %d", resp.StatusCode)
+	if err := ValidateWebhookResponse(webhook, resp.StatusCode, respBody); err != nil {
+		return err
 	}
 
 	log.Printf("钉钉通知发送成功")
+	return nil
+}
+
+func ValidateWebhookResponse(webhook string, statusCode int, respBody []byte) error {
+	if statusCode != http.StatusOK {
+		return fmt.Errorf("推送失败，状态码: %d, 响应: %s", statusCode, string(respBody))
+	}
+
+	parsedURL, err := url.Parse(webhook)
+	if err != nil {
+		return nil
+	}
+
+	host := strings.ToLower(parsedURL.Host)
+	body := strings.TrimSpace(string(respBody))
+	if body == "" {
+		return nil
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(respBody, &payload); err != nil {
+		return nil
+	}
+
+	switch {
+	case strings.Contains(host, "dingtalk.com"):
+		if code, ok := payload["errcode"].(float64); ok && int(code) != 0 {
+			return fmt.Errorf("钉钉发送失败: errcode=%d errmsg=%v", int(code), payload["errmsg"])
+		}
+	case strings.Contains(host, "qyapi.weixin.qq.com"):
+		if code, ok := payload["errcode"].(float64); ok && int(code) != 0 {
+			return fmt.Errorf("企业微信发送失败: errcode=%d errmsg=%v", int(code), payload["errmsg"])
+		}
+	case strings.Contains(host, "open.feishu.cn"):
+		if code, ok := payload["code"].(float64); ok && int(code) != 0 {
+			return fmt.Errorf("飞书发送失败: code=%d msg=%v", int(code), payload["msg"])
+		}
+		if code, ok := payload["StatusCode"].(float64); ok && int(code) != 0 {
+			return fmt.Errorf("飞书发送失败: StatusCode=%d StatusMessage=%v", int(code), payload["StatusMessage"])
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/pi-agent/agent.go
+++ b/pkg/pi-agent/agent.go
@@ -212,8 +212,24 @@ func (h *AgentHandler) getOrCreateSession(sessionID, modelName string) (*agent.A
 				return sd.agent, sessionID
 			}
 		}
+		if restored := h.restoreSessionLocked(sessionID, modelName); restored != nil {
+			return restored, sessionID
+		}
 	}
 
+	ag, resolvedModelName := h.newAgent(modelName)
+	if ag == nil {
+		return nil, ""
+	}
+
+	newID := fmt.Sprintf("sess_%d", time.Now().UnixNano())
+	h.sessions[newID] = &sessionData{agent: ag, modelName: resolvedModelName}
+
+	log.Printf("[PiAgent] 创建会话 %s (模型: %s)", newID, resolvedModelName)
+	return ag, newID
+}
+
+func (h *AgentHandler) newAgent(modelName string) (*agent.Agent, string) {
 	mc := h.getDefaultModel()
 	if modelName != "" {
 		if m := h.getModel(modelName); m != nil {
@@ -271,12 +287,62 @@ func (h *AgentHandler) getOrCreateSession(sessionID, modelName string) (*agent.A
 	ag.SetSystemPrompt(systemPrompt)
 	ag.SetThinkingLevel(level)
 	ag.SetTools(h.tools)
+	return ag, mc.Name
+}
 
-	newID := fmt.Sprintf("sess_%d", time.Now().UnixNano())
-	h.sessions[newID] = &sessionData{agent: ag, modelName: mc.Name}
+func (h *AgentHandler) restoreSessionLocked(sessionID, modelName string) *agent.Agent {
+	var session database.AiSession
+	if err := h.db.Where("id = ?", sessionID).First(&session).Error; err != nil {
+		return nil
+	}
 
-	log.Printf("[PiAgent] 创建会话 %s (模型: %s)", newID, mc.Name)
-	return ag, newID
+	resumeModelName := strings.TrimSpace(modelName)
+	if resumeModelName == "" {
+		resumeModelName = strings.TrimSpace(session.ModelName)
+	}
+
+	ag, resolvedModelName := h.newAgent(resumeModelName)
+	if ag == nil {
+		return nil
+	}
+
+	var messages []database.AiMessage
+	h.db.Where("session_id = ?", sessionID).Order("created_at asc, id asc").Find(&messages)
+	for _, m := range messages {
+		switch m.Role {
+		case "user":
+			ag.AppendMessage(ai.NewUserMessage(m.Content))
+		case "assistant":
+			msg := ai.NewAssistantMessage(ai.ApiOpenAICompletions, ai.ProviderOpenAI, resolvedModelName)
+			msg.Content = append(msg.Content, ai.NewTextContentBlock(m.Content))
+			ag.AppendMessage(msg)
+		}
+	}
+
+	h.sessions[sessionID] = &sessionData{agent: ag, modelName: resolvedModelName}
+	log.Printf("[PiAgent] 恢复历史会话 %s (模型: %s, 消息数: %d)", sessionID, resolvedModelName, len(messages))
+	return ag
+}
+
+func (h *AgentHandler) buildSessionTitle(sessionID string) string {
+	var firstUserMessage database.AiMessage
+	if err := h.db.Where("session_id = ? AND role = ?", sessionID, "user").Order("created_at asc").First(&firstUserMessage).Error; err != nil {
+		return ""
+	}
+	return compactSessionTitle(firstUserMessage.Content, 28)
+}
+
+func compactSessionTitle(text string, limit int) string {
+	text = strings.TrimSpace(strings.ReplaceAll(text, "\n", " "))
+	text = strings.Join(strings.Fields(text), " ")
+	if text == "" {
+		return ""
+	}
+	runes := []rune(text)
+	if limit <= 0 || len(runes) <= limit {
+		return text
+	}
+	return string(runes[:limit]) + "..."
 }
 
 func (h *AgentHandler) handleChat(w http.ResponseWriter, r *http.Request) {
@@ -319,9 +385,18 @@ func (h *AgentHandler) handleChat(w http.ResponseWriter, r *http.Request) {
 
 	// Ensure session record exists in DB
 	h.db.Where("id = ?", sessionID).First(&database.AiSession{})
+	modelLabel := req.ModelName
+	if modelLabel == "" {
+		if sd, ok := h.sessions[sessionID]; ok {
+			modelLabel = sd.modelName
+		}
+	}
+	if modelLabel == "" && h.getDefaultModel() != nil {
+		modelLabel = h.getDefaultModel().Name
+	}
 	h.db.Create(&database.AiSession{
 		ID:        sessionID,
-		ModelName: h.getDefaultModel().Name,
+		ModelName: modelLabel,
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
 	})
@@ -411,6 +486,7 @@ func (h *AgentHandler) handleSessions(w http.ResponseWriter, r *http.Request) {
 			UpdatedAt: s.UpdatedAt,
 			MsgCount:  count,
 			ModelName: s.ModelName,
+			Title:     h.buildSessionTitle(s.ID),
 		})
 	}
 
@@ -442,6 +518,7 @@ func (h *AgentHandler) handleSessionByID(w http.ResponseWriter, r *http.Request)
 				CreatedAt: session.CreatedAt,
 				UpdatedAt: session.UpdatedAt,
 				ModelName: session.ModelName,
+				Title:     h.buildSessionTitle(session.ID),
 			},
 		}
 		detail.MsgCount = int64(len(messages))

--- a/pkg/pi-agent/models.go
+++ b/pkg/pi-agent/models.go
@@ -18,6 +18,7 @@ type SessionInfo struct {
 	UpdatedAt time.Time `json:"updated_at"`
 	MsgCount  int64     `json:"msg_count"`
 	ModelName string    `json:"model_name,omitempty"`
+	Title     string    `json:"title,omitempty"`
 }
 
 type SessionDetail struct {

--- a/pkg/pi-agent/runtime_config.go
+++ b/pkg/pi-agent/runtime_config.go
@@ -1,0 +1,171 @@
+package piagent
+
+import (
+	"encoding/json"
+	"strings"
+
+	"PromAI/pkg/config"
+	"PromAI/pkg/database"
+)
+
+func resolveToolDatasource(base *config.Config, db DB, datasource string) (*database.DataSource, string, string, string, string) {
+	promURL := base.PrometheusURL
+	promUser := base.PrometheusUsername
+	promPass := base.PrometheusPassword
+	dsName := promURL
+
+	datasource = strings.TrimSpace(datasource)
+	if datasource == "" {
+		return nil, promURL, promUser, promPass, dsName
+	}
+	if strings.HasPrefix(datasource, "http://") || strings.HasPrefix(datasource, "https://") {
+		return nil, datasource, promUser, promPass, datasource
+	}
+
+	var ds database.DataSource
+	if db.Model(&database.DataSource{}).Where("enabled = ? AND LOWER(name) = LOWER(?)", true, datasource).First(&ds).Error() != nil {
+		like := "%" + datasource + "%"
+		if db.Model(&database.DataSource{}).Where("enabled = ? AND (name LIKE ? OR url LIKE ?)", true, like, like).First(&ds).Error() != nil {
+			return nil, promURL, promUser, promPass, dsName
+		}
+	}
+
+	database.NormalizeDataSourceTemplateFields(&ds)
+	return &ds, ds.URL, ds.Username, ds.Password, ds.Name
+}
+
+func buildToolRuntimeMetricConfig(base *config.Config, db DB, ds *database.DataSource) (*config.Config, error) {
+	cfg := cloneToolConfig(base)
+	if ds != nil && strings.TrimSpace(ds.ProjectName) != "" {
+		cfg.ProjectName = strings.TrimSpace(ds.ProjectName)
+	}
+	if ds == nil {
+		return cfg, nil
+	}
+
+	configs, err := loadToolEffectiveMetricConfigs(db, ds)
+	if err != nil {
+		return nil, err
+	}
+	if len(configs) == 0 {
+		cfg.MetricTypes = nil
+		return cfg, nil
+	}
+	cfg.MetricTypes = buildToolMetricTypesFromConfigs(db, configs)
+	return cfg, nil
+}
+
+func loadToolEffectiveMetricConfigs(db DB, ds *database.DataSource) ([]database.MetricConfig, error) {
+	if ds == nil {
+		return nil, nil
+	}
+	database.NormalizeDataSourceTemplateFields(ds)
+	if len(ds.TemplateIDs) > 0 {
+		return loadToolTemplateMetricConfigs(db, ds.TemplateIDs)
+	}
+	var configs []database.MetricConfig
+	if err := db.Model(&database.MetricConfig{}).
+		Where("(datasource_id IS NULL OR datasource_id = ?) AND metric_type_id IS NOT NULL", ds.ID).
+		Order("metric_type_id asc, sort_order asc, id asc").
+		Find(&configs).Error(); err != nil {
+		return nil, err
+	}
+	return configs, nil
+}
+
+func loadToolTemplateMetricConfigs(db DB, templateIDs []uint) ([]database.MetricConfig, error) {
+	templateIDs = database.ParseTemplateIDs(database.EncodeTemplateIDs(templateIDs))
+	if len(templateIDs) == 0 {
+		return nil, nil
+	}
+
+	var merged []database.MetricConfig
+	indexByID := make(map[uint]int)
+	for _, templateID := range templateIDs {
+		var links []database.InspectionTemplateMetric
+		if err := db.Model(&database.InspectionTemplateMetric{}).Where("template_id = ?", templateID).Find(&links).Error(); err != nil {
+			return nil, err
+		}
+		if len(links) == 0 {
+			continue
+		}
+
+		configIDs := make([]uint, 0, len(links))
+		for _, link := range links {
+			configIDs = append(configIDs, link.MetricConfigID)
+		}
+
+		var configs []database.MetricConfig
+		if err := db.Model(&database.MetricConfig{}).
+			Where("id IN ?", configIDs).
+			Order("metric_type_id asc, sort_order asc, id asc").
+			Find(&configs).Error(); err != nil {
+			return nil, err
+		}
+
+		for i := range configs {
+			var override database.TemplateMetricOverride
+			if db.Model(&database.TemplateMetricOverride{}).Where("template_id = ? AND metric_config_id = ?", templateID, configs[i].ID).First(&override).Error() == nil {
+				override.Apply(&configs[i])
+			}
+			if idx, ok := indexByID[configs[i].ID]; ok {
+				merged[idx] = configs[i]
+			} else {
+				indexByID[configs[i].ID] = len(merged)
+				merged = append(merged, configs[i])
+			}
+		}
+	}
+	return merged, nil
+}
+
+func buildToolMetricTypesFromConfigs(db DB, selectedConfigs []database.MetricConfig) []config.MetricType {
+	if len(selectedConfigs) == 0 {
+		return nil
+	}
+	grouped := make(map[uint][]database.MetricConfig)
+	for _, cfg := range selectedConfigs {
+		grouped[cfg.MetricTypeID] = append(grouped[cfg.MetricTypeID], cfg)
+	}
+
+	var metricTypes []database.MetricType
+	db.Model(&database.MetricType{}).Order("sort_order asc, id asc").Find(&metricTypes)
+
+	result := make([]config.MetricType, 0, len(grouped))
+	for _, mt := range metricTypes {
+		configs := grouped[mt.ID]
+		if len(configs) == 0 {
+			continue
+		}
+		item := config.MetricType{Type: mt.TypeName}
+		for _, cfg := range configs {
+			var labels map[string]string
+			if cfg.LabelsJSON != "" {
+				_ = json.Unmarshal([]byte(cfg.LabelsJSON), &labels)
+			}
+			item.Metrics = append(item.Metrics, config.MetricConfig{
+				Name:            cfg.Name,
+				Description:     cfg.Description,
+				Query:           cfg.Query,
+				Threshold:       cfg.Threshold,
+				Unit:            cfg.Unit,
+				Labels:          labels,
+				ThresholdType:   cfg.ThresholdType,
+				ThresholdStatus: cfg.ThresholdStatus,
+			})
+		}
+		result = append(result, item)
+	}
+	return result
+}
+
+func cloneToolConfig(base *config.Config) *config.Config {
+	if base == nil {
+		return &config.Config{}
+	}
+	cloned := *base
+	if base.MetricTypes != nil {
+		cloned.MetricTypes = append([]config.MetricType(nil), base.MetricTypes...)
+	}
+	return &cloned
+}

--- a/pkg/pi-agent/tools_action.go
+++ b/pkg/pi-agent/tools_action.go
@@ -14,8 +14,8 @@ import (
 	"PromAI/pkg/metrics"
 	"PromAI/pkg/prometheus"
 	"PromAI/pkg/report"
-	agent "github.com/jay-y/pi/pkg/ai-agent"
 	"github.com/jay-y/pi/pkg/ai"
+	agent "github.com/jay-y/pi/pkg/ai-agent"
 )
 
 type InspectTaskItem struct {
@@ -62,9 +62,11 @@ func NewTriggerInspectTool(cfg *config.Config, collector *metrics.Collector, db 
 	}
 }
 
-func (t *TriggerInspectTool) GetName() string         { return "trigger_inspect" }
-func (t *TriggerInspectTool) GetLabel() string        { return "触发巡检" }
-func (t *TriggerInspectTool) GetDescription() string  { return "对指定数据源手动触发一次巡检" }
+func (t *TriggerInspectTool) GetName() string  { return "trigger_inspect" }
+func (t *TriggerInspectTool) GetLabel() string { return "触发巡检" }
+func (t *TriggerInspectTool) GetDescription() string {
+	return "对指定数据源手动触发一次巡检"
+}
 
 func (t *TriggerInspectTool) GetParameters() map[string]any {
 	return map[string]any{
@@ -82,34 +84,21 @@ func (t *TriggerInspectTool) Execute(ctx context.Context, params map[string]any,
 	dsParam, _ := params["datasource"].(string)
 	log.Printf("[PiAgent] 工具调用: trigger_inspect datasource=%s", dsParam)
 
-	promURL := t.config.PrometheusURL
-	promUser := t.config.PrometheusUsername
-	promPass := t.config.PrometheusPassword
-
-	dsName := promURL
-	if dsParam != "" {
-		if strings.HasPrefix(dsParam, "http://") || strings.HasPrefix(dsParam, "https://") {
-			promURL = dsParam
-			dsName = dsParam
-		} else {
-			// 精确匹配: name 不区分大小写
-			var ds DataSource
-			if t.db.Model(&DataSource{}).Where("enabled = ? AND LOWER(name) = LOWER(?)", true, dsParam).First(&ds).Error() == nil {
-				promURL = ds.URL
-				promUser = ds.Username
-				promPass = ds.Password
-				dsName = ds.Name
-			} else {
-				// 模糊匹配: 子串包含
-				like := "%" + dsParam + "%"
-				if t.db.Model(&DataSource{}).Where("enabled = ? AND name LIKE ?", true, like).First(&ds).Error() == nil {
-					promURL = ds.URL
-					promUser = ds.Username
-					promPass = ds.Password
-					dsName = ds.Name
-				}
-			}
+	ds, promURL, promUser, promPass, dsName := resolveToolDatasource(t.config, t.db, dsParam)
+	runtimeCfg, err := buildToolRuntimeMetricConfig(t.config, t.db, ds)
+	if err != nil {
+		return &agent.AgentToolResult{
+			Content: []ai.ContentBlock{ai.NewTextContentBlock(fmt.Sprintf("加载数据源巡检配置失败: %v", err))},
+		}, nil
+	}
+	if len(runtimeCfg.MetricTypes) == 0 {
+		target := dsName
+		if ds != nil {
+			target = ds.Name
 		}
+		return &agent.AgentToolResult{
+			Content: []ai.ContentBlock{ai.NewTextContentBlock(fmt.Sprintf("数据源 %s 未配置巡检模板或指标，无法执行巡检", target))},
+		}, nil
 	}
 
 	client, err := prometheus.NewClient(promURL, promUser, promPass)
@@ -143,8 +132,14 @@ func (t *TriggerInspectTool) Execute(ctx context.Context, params map[string]any,
 	// 创建持久化巡检记录
 	now := time.Now()
 	t.db.Create(&InspectRecord{
-		TaskID:         taskID,
-		Status:         "running",
+		TaskID: taskID,
+		Status: "running",
+		DatasourceID: func() *uint {
+			if ds != nil {
+				return &ds.ID
+			}
+			return nil
+		}(),
 		DatasourceName: dsName,
 		Message:        "正在执行巡检...",
 		StartedAt:      now,
@@ -152,7 +147,7 @@ func (t *TriggerInspectTool) Execute(ctx context.Context, params map[string]any,
 	})
 
 	go func() {
-		dataCollector := metrics.NewCollectorWithURL(client.API, t.config, promURL)
+		dataCollector := metrics.NewCollectorWithURL(client.API, runtimeCfg, promURL)
 		data, err := dataCollector.CollectMetrics()
 		if err != nil {
 			t.tasksMu.Lock()
@@ -216,12 +211,12 @@ func (t *TriggerInspectTool) Execute(ctx context.Context, params map[string]any,
 							}
 						}
 						detail := map[string]any{
-							"type":     typeName,
-							"name":     m.Name,
-							"value":    m.Value,
-							"unit":     m.Unit,
-							"status":   m.Status,
-							"labels":   labels,
+							"type":   typeName,
+							"name":   m.Name,
+							"value":  m.Value,
+							"unit":   m.Unit,
+							"status": m.Status,
+							"labels": labels,
 						}
 						if m.ThresholdType != "" {
 							detail["threshold"] = m.Threshold
@@ -248,17 +243,21 @@ func (t *TriggerInspectTool) Execute(ctx context.Context, params map[string]any,
 		}
 
 		snapshot := map[string]any{
-			"datasource_name":   data.Datasource,
-			"total_metrics":     totalMetrics,
-			"critical_count":    criticalCount,
-			"warning_count":     warningCount,
-			"abnormal_details":  abnormalDetails,
-			"type_summaries":    typeSummaries,
+			"datasource_name":  data.Datasource,
+			"total_metrics":    totalMetrics,
+			"critical_count":   criticalCount,
+			"warning_count":    warningCount,
+			"abnormal_details": abnormalDetails,
+			"type_summaries":   typeSummaries,
 		}
 		metricsJSON, _ := json.Marshal(snapshot)
 
-		t.db.Create(&ReportRecord{
-			Title:          fmt.Sprintf("巡检报告 - %s", time.Now().Format("2006-01-02 15:04")),
+		titlePrefix := runtimeCfg.ProjectName
+		if titlePrefix == "" {
+			titlePrefix = "巡检报告"
+		}
+		record := ReportRecord{
+			Title:          fmt.Sprintf("%s - %s", titlePrefix, time.Now().Format("2006-01-02 15:04")),
 			DatasourceName: data.Datasource,
 			FilePath:       reportPath,
 			FileSize:       fileSize,
@@ -269,7 +268,11 @@ func (t *TriggerInspectTool) Execute(ctx context.Context, params map[string]any,
 			Status:         status,
 			MetricsJSON:    string(metricsJSON),
 			CreatedAt:      time.Now(),
-		})
+		}
+		if ds != nil {
+			record.DatasourceID = &ds.ID
+		}
+		t.db.Create(&record)
 
 		reportURL := "/api/promai/reports/" + reportPath[len("reports/"):]
 		t.tasksMu.Lock()
@@ -294,9 +297,9 @@ type QueryTaskTool struct {
 	parent *TriggerInspectTool
 }
 
-func (t *QueryTaskTool) GetName() string         { return "query_task" }
-func (t *QueryTaskTool) GetLabel() string        { return "查询任务" }
-func (t *QueryTaskTool) GetDescription() string  { return "查询巡检任务的执行进度和结果" }
+func (t *QueryTaskTool) GetName() string        { return "query_task" }
+func (t *QueryTaskTool) GetLabel() string       { return "查询任务" }
+func (t *QueryTaskTool) GetDescription() string { return "查询巡检任务的执行进度和结果" }
 
 func (t *QueryTaskTool) GetParameters() map[string]any {
 	return map[string]any{

--- a/pkg/pi-agent/tools_datasource.go
+++ b/pkg/pi-agent/tools_datasource.go
@@ -6,17 +6,20 @@ import (
 	"log"
 	"strings"
 
-	agent "github.com/jay-y/pi/pkg/ai-agent"
+	"PromAI/pkg/database"
 	"github.com/jay-y/pi/pkg/ai"
+	agent "github.com/jay-y/pi/pkg/ai-agent"
 )
 
 type ListDatasourcesTool struct {
 	db DB
 }
 
-func (t *ListDatasourcesTool) GetName() string         { return "list_datasources" }
-func (t *ListDatasourcesTool) GetLabel() string        { return "列出数据源" }
-func (t *ListDatasourcesTool) GetDescription() string  { return "列出所有数据源及其基本信息" }
+func (t *ListDatasourcesTool) GetName() string  { return "list_datasources" }
+func (t *ListDatasourcesTool) GetLabel() string { return "列出数据源" }
+func (t *ListDatasourcesTool) GetDescription() string {
+	return "列出所有数据源及其基本信息"
+}
 
 func (t *ListDatasourcesTool) GetParameters() map[string]any {
 	return map[string]any{
@@ -46,11 +49,23 @@ func (t *ListDatasourcesTool) Execute(ctx context.Context, params map[string]any
 			if ds.IsDefault {
 				def = " [默认]"
 			}
-			tmpl := ""
-			if ds.TemplateID != nil {
-				tmpl = fmt.Sprintf(" [模板ID: %d]", *ds.TemplateID)
+			templateIDs := database.ParseTemplateIDs(ds.TemplateIDsRaw)
+			if len(templateIDs) == 0 && ds.TemplateID != nil {
+				templateIDs = []uint{*ds.TemplateID}
 			}
-			lines = append(lines, fmt.Sprintf("  • %s%s — %s %s%s", ds.Name, def, ds.URL, status, tmpl))
+			tmpl := ""
+			if len(templateIDs) > 0 {
+				parts := make([]string, 0, len(templateIDs))
+				for _, id := range templateIDs {
+					parts = append(parts, fmt.Sprintf("%d", id))
+				}
+				tmpl = fmt.Sprintf(" [模板IDs: %s]", strings.Join(parts, ", "))
+			}
+			project := ""
+			if ds.ProjectName != "" {
+				project = fmt.Sprintf(" [项目: %s]", ds.ProjectName)
+			}
+			lines = append(lines, fmt.Sprintf("  • %s%s — %s %s%s%s", ds.Name, def, ds.URL, status, tmpl, project))
 		}
 	}
 
@@ -83,6 +98,8 @@ type DataSource struct {
 	IsDefault      bool   `json:"is_default"`
 	Enabled        bool   `json:"enabled"`
 	TemplateID     *uint  `json:"template_id"`
+	TemplateIDsRaw string `gorm:"column:template_ids" json:"-"`
+	ProjectName    string `json:"project_name"`
 	NotifyChannels string `json:"notify_channels"`
 }
 

--- a/pkg/pi-agent/tools_push.go
+++ b/pkg/pi-agent/tools_push.go
@@ -18,11 +18,12 @@ import (
 	"time"
 
 	"PromAI/pkg/config"
+	"PromAI/pkg/database"
 	"PromAI/pkg/notify"
 	"PromAI/pkg/report"
 
-	agent "github.com/jay-y/pi/pkg/ai-agent"
 	"github.com/jay-y/pi/pkg/ai"
+	agent "github.com/jay-y/pi/pkg/ai-agent"
 	gomail "github.com/jordan-wright/email"
 )
 
@@ -35,9 +36,11 @@ func NewPushReportTool(cfg *config.Config, db DB) *PushReportTool {
 	return &PushReportTool{cfg: cfg, db: db}
 }
 
-func (t *PushReportTool) GetName() string        { return "push_report" }
-func (t *PushReportTool) GetLabel() string        { return "推送报告" }
-func (t *PushReportTool) GetDescription() string  { return "将巡检报告或自定义内容推送到通知渠道（企业微信/钉钉/飞书/邮件）" }
+func (t *PushReportTool) GetName() string  { return "push_report" }
+func (t *PushReportTool) GetLabel() string { return "推送报告" }
+func (t *PushReportTool) GetDescription() string {
+	return "将巡检报告或自定义内容推送到通知渠道（企业微信/钉钉/飞书/邮件）"
+}
 
 func (t *PushReportTool) GetParameters() map[string]any {
 	return map[string]any{
@@ -110,6 +113,8 @@ func (t *PushReportTool) Execute(ctx context.Context, params map[string]any, onU
 	var err error
 	switch channel {
 	case "wechat_work":
+		cfg := t.loadWeChatWorkConfig()
+		cfg.Enabled = true
 		if webhookURL != "" {
 			proxyURL := ""
 			if strings.HasPrefix(webhookURL, "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=") {
@@ -119,14 +124,29 @@ func (t *PushReportTool) Execute(ctx context.Context, params map[string]any, onU
 				err = fmt.Errorf("企业微信 webhook 地址格式不正确，应以 https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key= 开头")
 			}
 		} else {
-			err = notify.SendWeChatWorkWithContext(ctx, t.cfg.Notifications.WeChatWork, record.FilePath, projectName, record.DatasourceName, summary)
+			err = notify.SendWeChatWorkWithContext(ctx, cfg, record.FilePath, projectName, record.DatasourceName, summary)
 		}
 	case "dingtalk":
-		err = notify.SendDingtalkWithContext(ctx, t.cfg.Notifications.Dingtalk, record.FilePath, projectName, record.DatasourceName, summary)
+		cfg := t.loadDingtalkConfig()
+		cfg.Enabled = true
+		if webhookURL != "" {
+			cfg.Webhook = webhookURL
+			cfg.Secret = ""
+		}
+		err = notify.SendDingtalkWithContext(ctx, cfg, record.FilePath, projectName, record.DatasourceName, summary)
 	case "feishu":
-		err = notify.SendFeishuWithContext(ctx, t.cfg.Notifications.Feishu, record.FilePath, projectName, record.DatasourceName, summary)
+		cfg := t.loadFeishuConfig()
+		cfg.Enabled = true
+		if webhookURL != "" {
+			cfg.Webhook = webhookURL
+			cfg.Secret = ""
+			cfg.VerifySign = false
+		}
+		err = notify.SendFeishuWithContext(ctx, cfg, record.FilePath, projectName, record.DatasourceName, summary)
 	case "email":
-		err = notify.SendEmailWithContext(ctx, t.cfg.Notifications.Email, record.FilePath, projectName, record.DatasourceName, summary)
+		cfg := t.loadEmailConfig()
+		cfg.Enabled = true
+		err = notify.SendEmailWithContext(ctx, cfg, record.FilePath, projectName, record.DatasourceName, summary)
 	default:
 		return &agent.AgentToolResult{
 			Content: []ai.ContentBlock{ai.NewTextContentBlock(fmt.Sprintf("不支持的渠道: %s，可选: wechat_work, dingtalk, feishu, email", channel))},
@@ -154,12 +174,8 @@ func (t *PushReportTool) withReportDataFromSnapshot(ctx context.Context, record 
 	if err := json.Unmarshal([]byte(record.MetricsJSON), &snapshot); err != nil {
 		return ctx
 	}
-	tsRaw, ok := snapshot["type_summaries"]
-	if !ok {
-		return ctx
-	}
-	tsMap, ok := tsRaw.(map[string]any)
-	if !ok || len(tsMap) == 0 {
+	tsMap := buildTypeSummaryMap(snapshot)
+	if len(tsMap) == 0 {
 		return ctx
 	}
 	metricGroups := make(map[string]*report.MetricGroup)
@@ -187,6 +203,89 @@ func (t *PushReportTool) withReportDataFromSnapshot(ctx context.Context, record 
 	return ctx
 }
 
+func buildTypeSummaryMap(snapshot map[string]any) map[string]any {
+	if tsRaw, ok := snapshot["type_summaries"]; ok {
+		if tsMap, ok := tsRaw.(map[string]any); ok && len(tsMap) > 0 {
+			return tsMap
+		}
+		if tsList, ok := tsRaw.([]any); ok && len(tsList) > 0 {
+			converted := make(map[string]any, len(tsList))
+			for _, item := range tsList {
+				row, ok := item.(map[string]any)
+				if !ok {
+					continue
+				}
+				typeName, _ := row["type_name"].(string)
+				if strings.TrimSpace(typeName) == "" {
+					typeName, _ = row["type"].(string)
+				}
+				if strings.TrimSpace(typeName) == "" {
+					continue
+				}
+				converted[typeName] = map[string]any{
+					"critical": row["critical_count"],
+					"warning":  row["warning_count"],
+					"normal":   row["normal_count"],
+				}
+			}
+			if len(converted) > 0 {
+				return converted
+			}
+		}
+	}
+
+	metricsRaw, ok := snapshot["metrics"]
+	if !ok {
+		return nil
+	}
+	metricsList, ok := metricsRaw.([]any)
+	if !ok || len(metricsList) == 0 {
+		return nil
+	}
+
+	converted := make(map[string]map[string]float64)
+	for _, item := range metricsList {
+		row, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		typeName, _ := row["type_name"].(string)
+		if strings.TrimSpace(typeName) == "" {
+			continue
+		}
+		if _, exists := converted[typeName]; !exists {
+			converted[typeName] = map[string]float64{
+				"critical": 0,
+				"warning":  0,
+				"normal":   0,
+			}
+		}
+		status, _ := row["status"].(string)
+		switch status {
+		case "critical":
+			converted[typeName]["critical"]++
+		case "warning":
+			converted[typeName]["warning"]++
+		default:
+			converted[typeName]["normal"]++
+		}
+	}
+
+	if len(converted) == 0 {
+		return nil
+	}
+
+	result := make(map[string]any, len(converted))
+	for typeName, counts := range converted {
+		result[typeName] = map[string]any{
+			"critical": counts["critical"],
+			"warning":  counts["warning"],
+			"normal":   counts["normal"],
+		}
+	}
+	return result
+}
+
 func getFloat(m map[string]any, key string) float64 {
 	if v, ok := m[key]; ok {
 		if f, ok := v.(float64); ok {
@@ -194,6 +293,74 @@ func getFloat(m map[string]any, key string) float64 {
 		}
 	}
 	return 0
+}
+
+func (t *PushReportTool) loadNotificationChannel(channelType string) *database.NotificationChannel {
+	var channel database.NotificationChannel
+	if t.db.Model(&database.NotificationChannel{}).Where("channel_type = ?", channelType).First(&channel).Error() != nil {
+		return nil
+	}
+	return &channel
+}
+
+func (t *PushReportTool) loadDingtalkConfig() notify.DingtalkConfig {
+	cfg := t.cfg.Notifications.Dingtalk
+	channel := t.loadNotificationChannel("dingtalk")
+	if channel == nil || channel.ConfigJSON == "" {
+		return cfg
+	}
+	var dbCfg notify.DingtalkConfig
+	if err := json.Unmarshal([]byte(channel.ConfigJSON), &dbCfg); err != nil {
+		log.Printf("[PiAgent] 解析钉钉通知配置失败: %v", err)
+		return cfg
+	}
+	dbCfg.Enabled = channel.Enabled
+	return dbCfg
+}
+
+func (t *PushReportTool) loadWeChatWorkConfig() notify.WeChatWorkConfig {
+	cfg := t.cfg.Notifications.WeChatWork
+	channel := t.loadNotificationChannel("wechat_work")
+	if channel == nil || channel.ConfigJSON == "" {
+		return cfg
+	}
+	var dbCfg notify.WeChatWorkConfig
+	if err := json.Unmarshal([]byte(channel.ConfigJSON), &dbCfg); err != nil {
+		log.Printf("[PiAgent] 解析企业微信通知配置失败: %v", err)
+		return cfg
+	}
+	dbCfg.Enabled = channel.Enabled
+	return dbCfg
+}
+
+func (t *PushReportTool) loadFeishuConfig() notify.FeishuConfig {
+	cfg := t.cfg.Notifications.Feishu
+	channel := t.loadNotificationChannel("feishu")
+	if channel == nil || channel.ConfigJSON == "" {
+		return cfg
+	}
+	var dbCfg notify.FeishuConfig
+	if err := json.Unmarshal([]byte(channel.ConfigJSON), &dbCfg); err != nil {
+		log.Printf("[PiAgent] 解析飞书通知配置失败: %v", err)
+		return cfg
+	}
+	dbCfg.Enabled = channel.Enabled
+	return dbCfg
+}
+
+func (t *PushReportTool) loadEmailConfig() notify.EmailConfig {
+	cfg := t.cfg.Notifications.Email
+	channel := t.loadNotificationChannel("email")
+	if channel == nil || channel.ConfigJSON == "" {
+		return cfg
+	}
+	var dbCfg notify.EmailConfig
+	if err := json.Unmarshal([]byte(channel.ConfigJSON), &dbCfg); err != nil {
+		log.Printf("[PiAgent] 解析邮件通知配置失败: %v", err)
+		return cfg
+	}
+	dbCfg.Enabled = channel.Enabled
+	return dbCfg
 }
 
 func (t *PushReportTool) pushCustomContent(ctx context.Context, channel, webhookURL, content string) (*agent.AgentToolResult, error) {
@@ -220,7 +387,7 @@ func (t *PushReportTool) pushCustomContent(ctx context.Context, channel, webhook
 func (t *PushReportTool) pushWeChatWorkCustom(projectName, webhookURL, content string) (*agent.AgentToolResult, error) {
 	webhook := webhookURL
 	if webhook == "" {
-		webhook = t.cfg.Notifications.WeChatWork.Webhook
+		webhook = t.loadWeChatWorkConfig().Webhook
 	}
 	if webhook == "" {
 		return &agent.AgentToolResult{Content: []ai.ContentBlock{ai.NewTextContentBlock("系统未配置企业微信 webhook")}}, nil
@@ -235,7 +402,7 @@ func (t *PushReportTool) pushWeChatWorkCustom(projectName, webhookURL, content s
 }
 
 func (t *PushReportTool) pushDingtalkCustom(projectName, webhookURL, content string) (*agent.AgentToolResult, error) {
-	cfg := t.cfg.Notifications.Dingtalk
+	cfg := t.loadDingtalkConfig()
 	webhook := webhookURL
 	if webhook == "" {
 		webhook = cfg.Webhook
@@ -259,7 +426,7 @@ func (t *PushReportTool) pushDingtalkCustom(projectName, webhookURL, content str
 }
 
 func (t *PushReportTool) pushFeishuCustom(projectName, webhookURL, content string) (*agent.AgentToolResult, error) {
-	cfg := t.cfg.Notifications.Feishu
+	cfg := t.loadFeishuConfig()
 	webhook := webhookURL
 	if webhook == "" {
 		webhook = cfg.Webhook
@@ -326,8 +493,8 @@ func sendWebhookPOST(webhook string, msg map[string]any) (*agent.AgentToolResult
 	}
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != http.StatusOK {
-		return &agent.AgentToolResult{Content: []ai.ContentBlock{ai.NewTextContentBlock(fmt.Sprintf("推送失败，状态码: %d, 响应: %s", resp.StatusCode, string(body)))}}, nil
+	if err := notify.ValidateWebhookResponse(webhook, resp.StatusCode, body); err != nil {
+		return &agent.AgentToolResult{Content: []ai.ContentBlock{ai.NewTextContentBlock(fmt.Sprintf("推送失败: %v", err))}}, nil
 	}
 	return &agent.AgentToolResult{Content: []ai.ContentBlock{ai.NewTextContentBlock("✅ 自定义内容推送成功")}}, nil
 }

--- a/pkg/pi-agent/tools_report.go
+++ b/pkg/pi-agent/tools_report.go
@@ -5,20 +5,23 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"path/filepath"
 	"strings"
 	"time"
 
-	agent "github.com/jay-y/pi/pkg/ai-agent"
 	"github.com/jay-y/pi/pkg/ai"
+	agent "github.com/jay-y/pi/pkg/ai-agent"
 )
 
 type ListReportsTool struct {
 	db DB
 }
 
-func (t *ListReportsTool) GetName() string         { return "list_reports" }
-func (t *ListReportsTool) GetLabel() string        { return "查询巡检报告" }
-func (t *ListReportsTool) GetDescription() string  { return "查询历史巡检报告列表，支持按数据源、状态、时间筛选" }
+func (t *ListReportsTool) GetName() string  { return "list_reports" }
+func (t *ListReportsTool) GetLabel() string { return "查询巡检报告" }
+func (t *ListReportsTool) GetDescription() string {
+	return "查询历史巡检报告列表，支持按数据源、状态、时间筛选"
+}
 
 func (t *ListReportsTool) GetParameters() map[string]any {
 	return map[string]any{
@@ -56,43 +59,57 @@ func (t *ListReportsTool) Execute(ctx context.Context, params map[string]any, on
 	if pageSize < 1 {
 		pageSize = 5
 	}
-
-	query := t.db.Model(&ReportRecord{}).Order("created_at desc")
-	if ds != "" {
-		query = query.Where("datasource_name LIKE ?", "%"+ds+"%")
-	}
-	if status != "" {
-		query = query.Where("status = ?", status)
-	}
-
-	var total int64
-	query.Count(&total)
+	normalizedStatus := normalizeReportStatus(status)
+	dsKeywords := t.resolveDatasourceKeywords(ds)
 
 	var records []ReportRecord
-	query.Offset(int((page - 1) * pageSize)).Limit(int(pageSize)).Find(&records)
+	t.db.Model(&ReportRecord{}).Order("created_at desc").Find(&records)
+	records = filterReportRecords(records, dsKeywords, normalizedStatus)
+	records = dedupeReportRecords(records)
+	total := int64(len(records))
+	start := int((page - 1) * pageSize)
+	end := start + int(pageSize)
+	if start > len(records) {
+		start = len(records)
+	}
+	if end > len(records) {
+		end = len(records)
+	}
+	pageRecords := records[start:end]
 
 	lines := []string{}
 	lines = append(lines, fmt.Sprintf("📋 巡检报告列表（共 %d 条，当前第 %.0f 页）", total, page))
 	lines = append(lines, "")
 
-	if len(records) == 0 {
-		lines = append(lines, "暂无报告")
-	} else {
-		for _, r := range records {
-			statusText := map[string]string{
-				"success": "✅ 正常",
-				"danger":  "🔴 高危",
-				"warning": "🟡 告警",
-			}[r.Status]
-			if statusText == "" {
-				statusText = r.Status
+	if len(pageRecords) == 0 && normalizedStatus == "" {
+		var inspectRecords []InspectRecord
+		t.db.Model(&InspectRecord{}).Order("created_at desc").Find(&inspectRecords)
+		inspectRecords = filterInspectRecords(inspectRecords, dsKeywords)
+		inspectRecords = dedupeInspectRecords(inspectRecords)
+		if len(inspectRecords) == 0 {
+			lines = append(lines, "暂无报告")
+		} else {
+			lines = append(lines, "report_records 暂无匹配结果，已回退到历史巡检任务记录：")
+			lines = append(lines, "")
+			for _, r := range inspectRecords[:minInt(len(inspectRecords), int(pageSize))] {
+				lines = append(lines, fmt.Sprintf("  📄 %s", fallbackInspectTitle(r)))
+				lines = append(lines, fmt.Sprintf("     数据源: %s | 状态: %s", r.DatasourceName, humanizeReportStatus(r.Status)))
+				lines = append(lines, fmt.Sprintf("     时间: %s", r.CreatedAt.Format("2006-01-02 15:04:05")))
+				lines = append(lines, fmt.Sprintf("     链接: [查看报告](%s)", r.ReportURL))
+				lines = append(lines, "")
 			}
+		}
+	} else {
+		for _, r := range pageRecords {
 			lines = append(lines, fmt.Sprintf("  📄 %s", r.Title))
-			lines = append(lines, fmt.Sprintf("     数据源: %s | 状态: %s", r.DatasourceName, statusText))
+			lines = append(lines, fmt.Sprintf("     数据源: %s | 状态: %s", r.DatasourceName, humanizeReportStatus(r.Status)))
 			lines = append(lines, fmt.Sprintf("     指标: %d | 告警: %d (严重: %d, 警告: %d)",
 				r.TotalMetrics, r.AlertCount, r.CriticalCount, r.WarningCount))
 			lines = append(lines, fmt.Sprintf("     时间: %s", r.CreatedAt.Format("2006-01-02 15:04:05")))
 			lines = append(lines, fmt.Sprintf("     ID: %d", r.ID))
+			if link := buildReportLink(r.FilePath); link != "" {
+				lines = append(lines, fmt.Sprintf("     链接: [查看报告](%s)", link))
+			}
 			lines = append(lines, "")
 		}
 	}
@@ -106,9 +123,11 @@ type GetReportDetailTool struct {
 	db DB
 }
 
-func (t *GetReportDetailTool) GetName() string         { return "get_report_detail" }
-func (t *GetReportDetailTool) GetLabel() string        { return "读取报告详情" }
-func (t *GetReportDetailTool) GetDescription() string  { return "读取特定巡检报告的详细指标数据" }
+func (t *GetReportDetailTool) GetName() string  { return "get_report_detail" }
+func (t *GetReportDetailTool) GetLabel() string { return "读取报告详情" }
+func (t *GetReportDetailTool) GetDescription() string {
+	return "读取特定巡检报告的详细指标数据"
+}
 
 func (t *GetReportDetailTool) GetParameters() map[string]any {
 	return map[string]any{
@@ -142,10 +161,13 @@ func (t *GetReportDetailTool) Execute(ctx context.Context, params map[string]any
 	lines := []string{}
 	lines = append(lines, fmt.Sprintf("📄 报告详情: %s", record.Title))
 	lines = append(lines, fmt.Sprintf("数据源: %s", record.DatasourceName))
-	lines = append(lines, fmt.Sprintf("状态: %s", record.Status))
+	lines = append(lines, fmt.Sprintf("状态: %s", humanizeReportStatus(record.Status)))
 	lines = append(lines, fmt.Sprintf("总指标: %d", record.TotalMetrics))
 	lines = append(lines, fmt.Sprintf("告警数: %d (严重: %d, 警告: %d)", record.AlertCount, record.CriticalCount, record.WarningCount))
 	lines = append(lines, fmt.Sprintf("生成时间: %s", record.CreatedAt.Format("2006-01-02 15:04:05")))
+	if link := buildReportLink(record.FilePath); link != "" {
+		lines = append(lines, fmt.Sprintf("报告链接: [查看报告](%s)", link))
+	}
 
 	if record.MetricsJSON != "" {
 		lines = append(lines, "")
@@ -190,6 +212,7 @@ func (t *GetReportDetailTool) Execute(ctx context.Context, params map[string]any
 type ReportRecord struct {
 	ID             uint      `json:"id"`
 	Title          string    `json:"title"`
+	DatasourceID   *uint     `json:"datasource_id"`
 	DatasourceName string    `json:"datasource_name"`
 	FilePath       string    `json:"file_path"`
 	FileSize       int64     `json:"file_size"`
@@ -203,3 +226,173 @@ type ReportRecord struct {
 }
 
 func (ReportRecord) TableName() string { return "report_records" }
+
+func (t *ListReportsTool) resolveDatasourceKeywords(keyword string) []string {
+	keyword = strings.TrimSpace(keyword)
+	if keyword == "" {
+		return nil
+	}
+	result := []string{strings.ToLower(keyword)}
+	var datasources []DataSource
+	t.db.Model(&DataSource{}).Find(&datasources)
+	for _, ds := range datasources {
+		if strings.Contains(strings.ToLower(ds.Name), strings.ToLower(keyword)) || strings.Contains(strings.ToLower(ds.URL), strings.ToLower(keyword)) {
+			result = append(result, strings.ToLower(ds.Name), strings.ToLower(ds.URL))
+		}
+	}
+	return uniqueStrings(result)
+}
+
+func filterReportRecords(records []ReportRecord, dsKeywords []string, status string) []ReportRecord {
+	result := make([]ReportRecord, 0, len(records))
+	for _, record := range records {
+		if status != "" && normalizeReportStatus(record.Status) != status {
+			continue
+		}
+		if len(dsKeywords) > 0 {
+			target := strings.ToLower(record.DatasourceName + " " + record.FilePath + " " + record.Title)
+			matched := false
+			for _, keyword := range dsKeywords {
+				if strings.Contains(target, keyword) {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				continue
+			}
+		}
+		result = append(result, record)
+	}
+	return result
+}
+
+func filterInspectRecords(records []InspectRecord, dsKeywords []string) []InspectRecord {
+	result := make([]InspectRecord, 0, len(records))
+	for _, record := range records {
+		if record.ReportURL == "" {
+			continue
+		}
+		status := strings.ToLower(record.Status)
+		if status != "completed" && status != "success" {
+			continue
+		}
+		if len(dsKeywords) > 0 {
+			target := strings.ToLower(record.DatasourceName + " " + record.ReportURL)
+			matched := false
+			for _, keyword := range dsKeywords {
+				if strings.Contains(target, keyword) {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				continue
+			}
+		}
+		result = append(result, record)
+	}
+	return result
+}
+
+func dedupeReportRecords(records []ReportRecord) []ReportRecord {
+	result := make([]ReportRecord, 0, len(records))
+	seen := make(map[string]struct{}, len(records))
+	for _, record := range records {
+		key := filepath.Base(record.FilePath)
+		if key == "." || key == "" {
+			key = fmt.Sprintf("report-%d", record.ID)
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, record)
+	}
+	return result
+}
+
+func dedupeInspectRecords(records []InspectRecord) []InspectRecord {
+	result := make([]InspectRecord, 0, len(records))
+	seen := make(map[string]struct{}, len(records))
+	for _, record := range records {
+		key := filepath.Base(record.ReportURL)
+		if key == "." || key == "" {
+			key = fmt.Sprintf("inspect-%d", record.ID)
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, record)
+	}
+	return result
+}
+
+func buildReportLink(filePath string) string {
+	name := filepath.Base(strings.TrimSpace(filePath))
+	if name == "" || name == "." {
+		return ""
+	}
+	return "/api/promai/reports/" + name
+}
+
+func normalizeReportStatus(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "", "all":
+		return ""
+	case "success", "normal", "completed":
+		return "success"
+	case "warning", "warn":
+		return "warning"
+	case "danger", "critical", "error", "failed":
+		return "danger"
+	default:
+		return strings.ToLower(strings.TrimSpace(status))
+	}
+}
+
+func humanizeReportStatus(status string) string {
+	switch normalizeReportStatus(status) {
+	case "success":
+		return "✅ 正常"
+	case "warning":
+		return "🟡 告警"
+	case "danger":
+		return "🔴 高危"
+	default:
+		return status
+	}
+}
+
+func fallbackInspectTitle(record InspectRecord) string {
+	name := filepath.Base(record.ReportURL)
+	if name == "" || name == "." {
+		return "巡检报告"
+	}
+	return name
+}
+
+func uniqueStrings(items []string) []string {
+	seen := make(map[string]struct{}, len(items))
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
+		}
+		if _, ok := seen[item]; ok {
+			continue
+		}
+		seen[item] = struct{}{}
+		result = append(result, item)
+	}
+	return result
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 )
@@ -87,7 +88,7 @@ func GetServerURL(r *http.Request) string {
 // GetReportURL 获取报告访问URL
 func GetReportURL(r *http.Request, reportFileName string) string {
 	serverURL := GetServerURL(r)
-	return serverURL + "/api/promai/reports/" + reportFileName
+	return strings.TrimRight(serverURL, "/") + "/api/promai/reports/" + url.PathEscape(reportFileName)
 }
 
 // GetServerURLFromContext 从配置中获取服务器URL
@@ -117,4 +118,9 @@ func GetServerURLFromContext(configReportURL string) string {
 
 	return scheme + "://localhost:" + port
 
+}
+
+func BuildReportURL(configReportURL, reportFileName string) string {
+	baseURL := strings.TrimRight(GetServerURLFromContext(configReportURL), "/")
+	return baseURL + "/api/promai/reports/" + url.PathEscape(reportFileName)
 }

--- a/runtime_config.go
+++ b/runtime_config.go
@@ -1,0 +1,202 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+
+	"PromAI/pkg/config"
+	"PromAI/pkg/database"
+)
+
+func resolveDatasourceConnection(base *config.Config, datasourceID uint, datasourceURL string) (*database.DataSource, string, string, string) {
+	promURL := base.PrometheusURL
+	promUser := base.PrometheusUsername
+	promPass := base.PrometheusPassword
+	if datasourceURL != "" {
+		return nil, datasourceURL, promUser, promPass
+	}
+	if datasourceID == 0 {
+		return nil, promURL, promUser, promPass
+	}
+
+	var ds database.DataSource
+	if database.DB.First(&ds, datasourceID).Error != nil {
+		return nil, promURL, promUser, promPass
+	}
+	database.NormalizeDataSourceTemplateFields(&ds)
+	return &ds, ds.URL, ds.Username, ds.Password
+}
+
+func applyDatasourceProjectConfig(base *config.Config, ds *database.DataSource) *config.Config {
+	cfg := cloneRuntimeConfig(base)
+	if ds != nil && strings.TrimSpace(ds.ProjectName) != "" {
+		cfg.ProjectName = strings.TrimSpace(ds.ProjectName)
+	}
+	return cfg
+}
+
+func loadEffectiveMetricConfigs(ds *database.DataSource) ([]database.MetricConfig, error) {
+	if ds == nil {
+		var configs []database.MetricConfig
+		err := database.DB.Where("metric_type_id IS NOT NULL").
+			Order("metric_type_id asc, sort_order asc, id asc").
+			Find(&configs).Error
+		return configs, err
+	}
+
+	database.NormalizeDataSourceTemplateFields(ds)
+	if len(ds.TemplateIDs) > 0 {
+		return loadTemplateMetricConfigs(ds.TemplateIDs)
+	}
+
+	var configs []database.MetricConfig
+	err := database.DB.
+		Where("(datasource_id IS NULL OR datasource_id = ?) AND metric_type_id IS NOT NULL", ds.ID).
+		Order("metric_type_id asc, sort_order asc, id asc").
+		Find(&configs).Error
+	return configs, err
+}
+
+func loadTemplateMetricConfigs(templateIDs []uint) ([]database.MetricConfig, error) {
+	templateIDs = database.ParseTemplateIDs(database.EncodeTemplateIDs(templateIDs))
+	if len(templateIDs) == 0 {
+		return nil, nil
+	}
+
+	var merged []database.MetricConfig
+	indexByID := make(map[uint]int)
+
+	for _, templateID := range templateIDs {
+		var links []database.InspectionTemplateMetric
+		if err := database.DB.Where("template_id = ?", templateID).Find(&links).Error; err != nil {
+			return nil, err
+		}
+		if len(links) == 0 {
+			continue
+		}
+
+		configIDs := make([]uint, 0, len(links))
+		for _, link := range links {
+			configIDs = append(configIDs, link.MetricConfigID)
+		}
+
+		var configs []database.MetricConfig
+		if err := database.DB.Where("id IN ?", configIDs).
+			Order("metric_type_id asc, sort_order asc, id asc").
+			Find(&configs).Error; err != nil {
+			return nil, err
+		}
+
+		for i := range configs {
+			var override database.TemplateMetricOverride
+			if database.DB.Where("template_id = ? AND metric_config_id = ?", templateID, configs[i].ID).First(&override).Error == nil {
+				override.Apply(&configs[i])
+			}
+			if idx, ok := indexByID[configs[i].ID]; ok {
+				merged[idx] = configs[i]
+				continue
+			}
+			indexByID[configs[i].ID] = len(merged)
+			merged = append(merged, configs[i])
+		}
+	}
+
+	return merged, nil
+}
+
+func buildRuntimeMetricConfig(base *config.Config, ds *database.DataSource, selectedConfigs []database.MetricConfig) *config.Config {
+	cfg := applyDatasourceProjectConfig(base, ds)
+	if len(selectedConfigs) == 0 && ds != nil {
+		configs, err := loadEffectiveMetricConfigs(ds)
+		if err == nil {
+			selectedConfigs = configs
+		}
+	}
+	if len(selectedConfigs) == 0 {
+		return cfg
+	}
+	cfg.MetricTypes = buildMetricTypesFromConfigs(selectedConfigs)
+	return cfg
+}
+
+func buildMetricTypesFromConfigs(selectedConfigs []database.MetricConfig) []config.MetricType {
+	if len(selectedConfigs) == 0 {
+		return nil
+	}
+
+	typeOrder := make([]database.MetricType, 0)
+	typeMap := make(map[uint]database.MetricType)
+	var allTypes []database.MetricType
+	database.DB.Order("sort_order asc, id asc").Find(&allTypes)
+	for _, mt := range allTypes {
+		typeMap[mt.ID] = mt
+	}
+
+	grouped := make(map[uint][]database.MetricConfig)
+	for _, cfg := range selectedConfigs {
+		grouped[cfg.MetricTypeID] = append(grouped[cfg.MetricTypeID], cfg)
+	}
+
+	for _, mt := range allTypes {
+		if len(grouped[mt.ID]) > 0 {
+			typeOrder = append(typeOrder, mt)
+		}
+	}
+
+	result := make([]config.MetricType, 0, len(typeOrder))
+	for _, mt := range typeOrder {
+		mtCfg := config.MetricType{Type: mt.TypeName}
+		for _, item := range grouped[mt.ID] {
+			var labels map[string]string
+			if item.LabelsJSON != "" {
+				_ = json.Unmarshal([]byte(item.LabelsJSON), &labels)
+			}
+			mtCfg.Metrics = append(mtCfg.Metrics, config.MetricConfig{
+				Name:            item.Name,
+				Description:     item.Description,
+				Query:           item.Query,
+				Threshold:       item.Threshold,
+				Unit:            item.Unit,
+				Labels:          labels,
+				ThresholdType:   item.ThresholdType,
+				ThresholdStatus: item.ThresholdStatus,
+			})
+		}
+		result = append(result, mtCfg)
+		delete(grouped, mt.ID)
+	}
+
+	for mtID, configs := range grouped {
+		mtCfg := config.MetricType{Type: typeMap[mtID].TypeName}
+		for _, item := range configs {
+			var labels map[string]string
+			if item.LabelsJSON != "" {
+				_ = json.Unmarshal([]byte(item.LabelsJSON), &labels)
+			}
+			mtCfg.Metrics = append(mtCfg.Metrics, config.MetricConfig{
+				Name:            item.Name,
+				Description:     item.Description,
+				Query:           item.Query,
+				Threshold:       item.Threshold,
+				Unit:            item.Unit,
+				Labels:          labels,
+				ThresholdType:   item.ThresholdType,
+				ThresholdStatus: item.ThresholdStatus,
+			})
+		}
+		result = append(result, mtCfg)
+	}
+
+	return result
+}
+
+func cloneRuntimeConfig(base *config.Config) *config.Config {
+	if base == nil {
+		return &config.Config{}
+	}
+	cloned := *base
+	if base.MetricTypes != nil {
+		cloned.MetricTypes = append([]config.MetricType(nil), base.MetricTypes...)
+	}
+	return &cloned
+}


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[fix]、[documentation] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

**在提出此拉取请求时，我确认了以下几点（请复选框）：**

- [x] 我已阅读并理解[贡献者指南]()。
- [x] 我已检查没有与此请求重复的拉取请求。
- [x] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭拉取请求。

**填写 PR 内容：**
  ## 变更说明

  本次主要修复 AI 助手、通知推送、定时巡检和部署配置相关问题。

  ## 主要修改

  ### 1. AI 巡检按数据源模板执行
  - 修复 AI 助手触发巡检时只读取全局 `config.yaml` 的问题
  - 改为按数据源绑定的模板/指标构造运行时配置
  - 支持使用数据源 `project_name` 作为报告标题
  - 当数据源未绑定模板/指标时，返回明确错误，不再生成空结果

  ### 2. AI 助手历史会话可恢复
  - 修复刷新页面后选择历史会话继续对话时自动新建会话的问题
  - 后端现在会从数据库恢复历史消息并重建 agent 上下文
  - 会话标题改为优先使用首条用户消息摘要，而不是模型名称

  ### 3. AI 报告推送通知修复
  - 修复 AI 助手推送通知时没有读取数据库中通知渠道配置的问题
  - 改为优先使用后台保存的通知配置，和“通知渠道测试”行为一致
  - 修复钉钉/企微/飞书仅判断 HTTP 200 的问题，增加响应体业务状态校验
  - 钉钉报告通知改为 `actionCard`，提供稳定的“查看完整报告”按钮
  - 报告链接改为绝对 URL，并对文件名做 URL 转义
  - 修复 AI 助手“推送最后一份巡检报告到邮件”时正文分类巡检内容为空的问题，兼容两种报告快照格式

  ### 4. 通知渠道配置持久化
  - 修复应用重启后通知渠道配置被 `config.yaml` 覆盖的问题
  - 启动初始化现在只补齐缺失通知渠道，不再覆盖数据库中的 webhook、secret、enabled 等配置

  ### 5. 定时巡检按默认数据源执行
  - 修复全局 `cron_schedule`（如 8 点、17 点）定时巡检未按数据源模板执行的问题
  - 现在会优先使用默认数据源
  - 如果没有默认数据源但仅有一个启用数据源，则自动使用该数据源
  - 从而正确应用数据源绑定模板，不再只走全局 `config.yaml`

  ### 6. SQL/模板初始化与部署补充
  - 增加基于 SQL 的指标/模板初始化支持
  - 补充 Helm chart 与外部 SQL 挂载方案
  - 增加 `REPORT_URL` 部署配置，用于生成外部可访问的报告链接
  - README 补充 Helm 部署说明

  ## 部署影响

  - 需要升级后端镜像才能生效
  - 推荐同时配置 `REPORT_URL`，确保钉钉/邮件中的报告链接可外部访问
